### PR TITLE
Validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [Unreleased]
+
+### Added
+
+- Public validator API for form integration and input validation
+- `TagValidator<T>` base class with `validate()`, `validateOrThrow()`, and `formatErrorMessage()` methods
+- Numeric validators: `RatingValidator`, `BpmValidator`, `YearValidator`, `TrackNumberValidator`, `DiscNumberValidator`
+- Date validator: `DateRecordedValidator` with comprehensive ISO-8601 format validation
+- Text validators: `TitleValidator`, `ArtistValidator`, `AlbumValidator` for required field validation
+- `TagValidators` convenience class providing static access to all validators
+- Static validator constants on tag classes (e.g., `TitleTag.validator`, `RatingTag.validator`)
+- `reactive_forms` integration support via `Validators.delegate()`
+- Comprehensive validator test suite with 153+ tests covering all validators
+- Automatic value normalization (trimming whitespace) in text validators
+
 ## [1.1.2] - 2025-09-21
 
 ### Fixed

--- a/doc/validators-quick-reference.md
+++ b/doc/validators-quick-reference.md
@@ -1,0 +1,192 @@
+# Tag Validators - Quick Reference
+
+## Import
+
+```dart
+import 'package:phonic/phonic.dart';
+```
+
+## Basic Validation
+
+```dart
+// Validate a value
+final error = TagValidators.rating.validate(userInput);
+
+if (error == null) {
+  // Valid ✓
+  final tag = RatingTag(userInput);
+} else {
+  // Invalid ✗
+  print('Error: $error');
+}
+```
+
+## Quick Boolean Check
+
+```dart
+if (RatingValidator.isValid(userInput)) {
+  // Value is valid
+}
+```
+
+## reactive_forms Integration
+
+```dart
+final form = FormGroup({
+  'rating': FormControl<int>(
+    validators: [
+      Validators.delegate(
+        (control) => TagValidators.rating.validate(control.value),
+      ),
+    ],
+  ),
+});
+```
+
+## Custom Error Messages
+
+```dart
+ReactiveTextField<int>(
+  formControlName: 'rating',
+  validationMessages: {
+    'outOfRange': (error) {
+      final e = error as Map;
+      return 'Must be ${e['min']}-${e['max']}, got ${e['actual']}';
+    },
+  },
+)
+```
+
+## Error Structure
+
+```dart
+// RatingValidator returns:
+{
+  'outOfRange': {
+    'min': 0,
+    'max': 100,
+    'actual': 150  // The invalid value
+  }
+}
+```
+
+## Available Validators
+
+| Validator | Range/Rule | Access |
+|-----------|------------|--------|
+| RatingValidator | 0-100 | `TagValidators.rating` or `RatingTag.validator` |
+
+## Common Patterns
+
+### Pre-validate Input
+
+```dart
+void handleUserInput(String text) {
+  final value = int.tryParse(text);
+  final error = TagValidators.rating.validate(value);
+  
+  if (error != null) {
+    showError(RatingTag.validator.formatErrorMessage(error));
+    return;
+  }
+  
+  audioFile.setTag(RatingTag(value!));
+}
+```
+
+### Form Validation
+
+```dart
+class MetadataForm {
+  final form = FormGroup({
+    'rating': FormControl<int>(
+      validators: [
+        Validators.delegate((c) => TagValidators.rating.validate(c.value)),
+      ],
+    ),
+  });
+}
+```
+
+### Batch Validation
+
+```dart
+final validRatings = userInputs
+  .where((value) => TagValidators.rating.validate(value) == null)
+  .toList();
+```
+
+## API Methods
+
+### TagValidator<T>
+
+```dart
+// Returns error map or null
+Map<String, dynamic>? validate(T? value)
+
+// Throws ArgumentError on invalid
+T validateOrThrow(T value)
+
+// Format error message
+String formatErrorMessage(Map<String, dynamic> error)
+```
+
+### RatingValidator
+
+```dart
+// Constants
+static const int min = 0;
+static const int max = 100;
+static const String outOfRangeError = 'outOfRange';
+
+// Quick check
+static bool isValid(int? value)
+```
+
+## Examples
+
+See full examples in:
+- `example/validator_usage_example.dart`
+- `example/reactive_forms_integration_example.dart`
+- `doc/validators.md`
+
+## Error Messages
+
+```dart
+// Use validator's built-in formatting
+final message = RatingTag.validator.formatErrorMessage(error);
+
+// Or create custom messages
+final data = error['outOfRange'];
+final message = 'Rating ${data['actual']} is out of range (${data['min']}-${data['max']})';
+```
+
+## Best Practices
+
+✅ **DO** validate early (on input change)  
+✅ **DO** use `isValid()` for simple checks  
+✅ **DO** reuse validator instances via `TagValidators`  
+✅ **DO** provide helpful error messages  
+
+❌ **DON'T** create new validator instances repeatedly  
+❌ **DON'T** use exceptions for validation flow  
+❌ **DON'T** forget to handle null values  
+
+## Migration
+
+```dart
+// Old way (still works)
+try {
+  final tag = RatingTag(userInput);
+} on ArgumentError catch (e) {
+  showError(e.message);
+}
+
+// New way (recommended)
+final error = TagValidators.rating.validate(userInput);
+if (error == null) {
+  final tag = RatingTag(userInput);
+} else {
+  showError(RatingTag.validator.formatErrorMessage(error));
+}
+```

--- a/doc/validators.md
+++ b/doc/validators.md
@@ -1,0 +1,68 @@
+# Tag Validators
+
+Phonic provides public validators for validating tag values before creating tags.
+
+## Quick Start
+
+```dart
+import 'package:phonic/phonic.dart';
+
+// Validate a rating value
+final error = TagValidators.rating.validate(150);
+if (error != null) {
+  print('Invalid rating: ${error['outOfRange']}');
+}
+
+// Or use the convenience method
+if (RatingValidator.isValid(85)) {
+  final tag = RatingTag(85);
+}
+```
+
+## Accessing Validators
+
+```dart
+// Via TagValidators
+TagValidators.rating.validate(value);
+
+// Via tag class
+RatingTag.validator.validate(value);
+
+// Direct instantiation
+const RatingValidator().validate(value);
+```
+
+## Usage
+
+### Pre-validation
+
+```dart
+final error = TagValidators.rating.validate(userInput);
+if (error != null) {
+  // Show error to user
+  showError(RatingTag.validator.formatErrorMessage(error));
+} else {
+  audioFile.setTag(RatingTag(userInput));
+}
+```
+
+### With Form Libraries
+
+Validators return `null` for valid values and an error map for invalid values, making them compatible with form validation libraries like reactive_forms:
+
+```dart
+Validators.delegate((control) => TagValidators.rating.validate(control.value))
+```
+
+## Available Validators
+
+- `RatingValidator` - Validates rating values (0-100 range)
+
+See individual validator class documentation for detailed API reference.
+
+## Examples
+
+Complete examples are available in the [example directory](../example/):
+- `validator_usage_example.dart` - Basic patterns
+- `reactive_forms_integration_example.dart` - Form integration
+- `error_handling_example.dart` - Custom error handling

--- a/example/error_handling_example.dart
+++ b/example/error_handling_example.dart
@@ -1,0 +1,215 @@
+/// Example demonstrating improved error handling with descriptive error keys
+///
+/// This example shows how the new error structure makes it easy to:
+/// 1. Identify specific validation problems
+/// 2. Provide precise user feedback
+/// 3. Handle different error types appropriately
+
+// ignore_for_file: avoid_print
+
+import 'package:phonic/phonic.dart';
+
+/// Simulate a form model
+class RatingFormModel {
+  int? _rating;
+  bool _touched = false;
+
+  void setRating(int? value) {
+    _rating = value;
+    _touched = true;
+  }
+
+  String? getError() {
+    if (!_touched) return null;
+
+    // In a real form, you might check for required first
+    if (_rating == null) {
+      return 'Rating is required';
+    }
+
+    // Then validate the value
+    final error = TagValidators.rating.validate(_rating);
+    if (error == null) return null;
+
+    // Handle different error types with appropriate messages
+    if (error.containsKey('outOfRange')) {
+      final data = error['outOfRange'] as Map<String, dynamic>;
+      return 'Rating must be between ${data['min']} and ${data['max']}. '
+          'You entered ${data['actual']}.';
+    }
+
+    return 'Invalid rating';
+  }
+
+  bool get isValid => _touched && _rating != null && getError() == null;
+}
+
+void main() {
+  print('=== Descriptive Error Keys Example ===\n');
+
+  // Example 1: Specific error handling based on error type
+  specificErrorHandling();
+
+  // Example 2: User-friendly error messages
+  userFriendlyMessages();
+
+  // Example 3: Form validation with multiple error types
+  formValidationExample();
+}
+
+/// Example 1: Handle different error types specifically
+void specificErrorHandling() {
+  print('Example 1: Specific Error Type Handling');
+  print('─' * 50);
+
+  final testCases = [
+    (150, 'Value too high'),
+    (-10, 'Value too low'),
+    (50, 'Valid value'),
+  ];
+
+  for (final (value, description) in testCases) {
+    final error = TagValidators.rating.validate(value);
+
+    if (error == null) {
+      print('✓ $description ($value): Valid');
+    } else {
+      // We can check the specific error type
+      if (error.containsKey('outOfRange')) {
+        final data = error['outOfRange'] as Map<String, dynamic>;
+        final actual = data['actual'] as int;
+        final min = data['min'] as int;
+        final max = data['max'] as int;
+
+        if (actual < min) {
+          print('✗ $description ($value): Too low (minimum is $min)');
+        } else {
+          print('✗ $description ($value): Too high (maximum is $max)');
+        }
+      }
+      // In the future, we could handle other error types:
+      // else if (error.containsKey('required')) { ... }
+      // else if (error.containsKey('invalidFormat')) { ... }
+    }
+  }
+  print('');
+}
+
+/// Example 2: Generate user-friendly messages for different error types
+void userFriendlyMessages() {
+  print('Example 2: User-Friendly Error Messages');
+  print('─' * 50);
+
+  String getUserMessage(Map<String, dynamic> error) {
+    // Handle outOfRange error
+    if (error.containsKey('outOfRange')) {
+      final data = error['outOfRange'] as Map<String, dynamic>;
+      final actual = data['actual'] as int;
+      final min = data['min'] as int;
+      final max = data['max'] as int;
+
+      if (actual < min) {
+        return '🔻 Oops! The rating $actual is too low. '
+            'Please choose a value of at least $min.';
+      } else {
+        return '🔺 Oops! The rating $actual is too high. '
+            'Please choose a value no greater than $max.';
+      }
+    }
+
+    // Future: Handle other error types
+    // if (error.containsKey('required')) {
+    //   return '⚠️ This field is required. Please enter a value.';
+    // }
+    // if (error.containsKey('invalidFormat')) {
+    //   return '❌ The format is incorrect. Please check your input.';
+    // }
+
+    return 'Invalid value';
+  }
+
+  final testValues = [200, -5, 75];
+  for (final value in testValues) {
+    final error = TagValidators.rating.validate(value);
+    if (error != null) {
+      print(getUserMessage(error));
+    } else {
+      print('✅ Rating $value is perfect!');
+    }
+  }
+  print('');
+}
+
+/// Example 3: Form validation with multiple potential error types
+void formValidationExample() {
+  print('Example 3: Form Validation');
+  print('─' * 50);
+
+  // Test the form model
+  final form = RatingFormModel();
+
+  print('Initial state:');
+  print('  Error: ${form.getError()}');
+  print('  Valid: ${form.isValid}');
+  print('');
+
+  print('After setting invalid value (150):');
+  form.setRating(150);
+  print('  Error: ${form.getError()}');
+  print('  Valid: ${form.isValid}');
+  print('');
+
+  print('After setting valid value (85):');
+  form.setRating(85);
+  print('  Error: ${form.getError()}');
+  print('  Valid: ${form.isValid}');
+  print('');
+}
+
+/// Example 4: Error type routing (commented out, shows future possibilities)
+/*
+void errorTypeRouting() {
+  print('Example 4: Error Type Routing');
+  print('─' * 50);
+
+  enum ValidationErrorType {
+    outOfRange,
+    required,
+    invalidFormat,
+    customError,
+  }
+
+  ValidationErrorType? getErrorType(Map<String, dynamic> error) {
+    if (error.containsKey('outOfRange')) return ValidationErrorType.outOfRange;
+    if (error.containsKey('required')) return ValidationErrorType.required;
+    if (error.containsKey('invalidFormat')) return ValidationErrorType.invalidFormat;
+    return ValidationErrorType.customError;
+  }
+
+  void handleError(Map<String, dynamic> error) {
+    switch (getErrorType(error)) {
+      case ValidationErrorType.outOfRange:
+        final data = error['outOfRange'];
+        print('Handle out of range: ${data['actual']} not in ${data['min']}-${data['max']}');
+        break;
+      case ValidationErrorType.required:
+        print('Handle required field error');
+        break;
+      case ValidationErrorType.invalidFormat:
+        print('Handle format error');
+        break;
+      case ValidationErrorType.customError:
+        print('Handle unknown error type');
+        break;
+      case null:
+        print('No error');
+        break;
+    }
+  }
+
+  final error = TagValidators.rating.validate(150);
+  if (error != null) {
+    handleError(error);
+  }
+}
+*/

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -47,7 +47,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.1.2"
   typed_data:
     dependency: transitive
     description:

--- a/example/validator_usage_example.dart
+++ b/example/validator_usage_example.dart
@@ -1,0 +1,215 @@
+/// Example demonstrating how to use Phonic validators with reactive_forms
+/// for input validation in Flutter applications.
+///
+/// This example shows:
+/// 1. Basic validator usage for pre-validation
+/// 2. Integration with reactive_forms
+/// 3. Custom error messages
+/// 4. Multiple validation scenarios
+
+// ignore_for_file: avoid_print
+
+import 'package:phonic/phonic.dart';
+
+void main() {
+  // Example 1: Direct validation before creating a tag
+  directValidationExample();
+
+  // Example 2: Using validators with reactive_forms (pseudo-code)
+  // This would be used in a real Flutter app
+  reactiveFormsExample();
+
+  // Example 3: Validation with custom error handling
+  customErrorHandlingExample();
+
+  // Example 4: Batch validation
+  batchValidationExample();
+}
+
+/// Example 1: Direct validation before creating a tag
+void directValidationExample() {
+  print('=== Direct Validation Example ===');
+
+  final userInput = 150; // Invalid rating
+
+  // Validate before creating the tag
+  final error = TagValidators.rating.validate(userInput);
+
+  if (error != null) {
+    final rangeError = error['outOfRange'] as Map<String, dynamic>;
+    print('Invalid rating: $userInput');
+    print('  Min allowed: ${rangeError['min']}');
+    print('  Max allowed: ${rangeError['max']}');
+    print('  You entered: ${rangeError['actual']}');
+  } else {
+    // Safe to create tag
+    final tag = RatingTag(userInput);
+    print('Created tag: ${tag.value}');
+  }
+
+  // Using the convenience method
+  if (RatingValidator.isValid(85)) {
+    final tag = RatingTag(85);
+    print('Valid rating tag created: ${tag.value}');
+  }
+
+  print('');
+}
+
+/// Example 2: Integration with reactive_forms
+///
+/// This is pseudo-code showing how you would use the validators
+/// in a real Flutter application with reactive_forms.
+void reactiveFormsExample() {
+  print('=== Reactive Forms Integration Example ===');
+  print('''
+In a Flutter app with reactive_forms:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+import 'package:phonic/phonic.dart';
+
+class RatingForm extends StatelessWidget {
+  final form = FormGroup({
+    'rating': FormControl<int>(
+      validators: [
+        Validators.required,
+        Validators.delegate(
+          (control) => TagValidators.rating.validate(control.value),
+        ),
+      ],
+    ),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ReactiveForm(
+      formGroup: form,
+      child: Column(
+        children: [
+          ReactiveTextField<int>(
+            formControlName: 'rating',
+            keyboardType: TextInputType.number,
+            decoration: InputDecoration(
+              labelText: 'Rating (0-100)',
+              helperText: 'Enter a rating between 0 and 100',
+            ),
+            validationMessages: {
+              'required': (error) => 'Rating is required',
+              'rating': (error) {
+                final e = error as Map;
+                return 'Rating must be \${e['min']}-\${e['max']}, you entered \${e['actual']}';
+              },
+            },
+          ),
+          ElevatedButton(
+            onPressed: () {
+              if (form.valid) {
+                final rating = form.control('rating').value as int;
+                // Create and save the tag
+                final tag = RatingTag(rating);
+                print('Rating tag created: \${tag.value}');
+              }
+            },
+            child: Text('Save Rating'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+''');
+  print('');
+}
+
+/// Example 3: Custom error handling
+void customErrorHandlingExample() {
+  print('=== Custom Error Handling Example ===');
+
+  String? validateAndGetErrorMessage(int? value) {
+    final error = TagValidators.rating.validate(value);
+    if (error == null) return null;
+
+    final data = error['outOfRange'] as Map<String, dynamic>;
+    final actual = data['actual'] as int;
+    final min = data['min'] as int;
+    final max = data['max'] as int;
+
+    if (actual < min) {
+      return 'Rating is too low. Minimum is $min.';
+    } else {
+      return 'Rating is too high. Maximum is $max.';
+    }
+  }
+
+  final testValues = [-10, 0, 50, 100, 150];
+
+  for (final value in testValues) {
+    final errorMessage = validateAndGetErrorMessage(value);
+    if (errorMessage != null) {
+      print('Rating $value: ✗ $errorMessage');
+    } else {
+      print('Rating $value: ✓ Valid');
+    }
+  }
+
+  print('');
+}
+
+/// Example 4: Batch validation for multiple values
+void batchValidationExample() {
+  print('=== Batch Validation Example ===');
+
+  final ratings = [85, 150, -5, 92, 200, 0, 100];
+
+  final validRatings = <int>[];
+  final invalidRatings = <Map<String, dynamic>>[];
+
+  for (final rating in ratings) {
+    final error = TagValidators.rating.validate(rating);
+    if (error == null) {
+      validRatings.add(rating);
+    } else {
+      invalidRatings.add({
+        'value': rating,
+        'error': error,
+      });
+    }
+  }
+
+  print('Valid ratings: $validRatings');
+  print('Invalid ratings:');
+  for (final invalid in invalidRatings) {
+    final value = invalid['value'];
+    final error = invalid['error'] as Map<String, dynamic>;
+    final data = error['outOfRange'] as Map<String, dynamic>;
+    print('  - $value (allowed range: ${data['min']}-${data['max']})');
+  }
+
+  print('');
+}
+
+/// Example 5: Using validators in a form builder pattern
+class AudioMetadataForm {
+  int? _rating;
+
+  String? get ratingError {
+    if (_rating == null) return null;
+    final error = TagValidators.rating.validate(_rating);
+    if (error == null) return null;
+    return RatingTag.validator.formatErrorMessage(error);
+  }
+
+  bool get isValid => _rating != null && ratingError == null;
+
+  void setRating(int value) {
+    _rating = value;
+  }
+
+  RatingTag? createRatingTag() {
+    if (!isValid) return null;
+    return RatingTag(_rating!);
+  }
+}

--- a/lib/phonic.dart
+++ b/lib/phonic.dart
@@ -91,6 +91,11 @@ export 'src/exceptions/phonic_exception.dart';
 export 'src/exceptions/tag_validation_exception.dart';
 export 'src/exceptions/unsupported_format_exception.dart';
 
+// Validators for input validation and form integration
+export 'src/validators/tag_validator.dart';
+export 'src/validators/rating_validator.dart';
+export 'src/validators/tag_validators.dart';
+
 // Utils
 export 'src/utils/lazy_artwork_loader.dart';
 

--- a/lib/phonic.dart
+++ b/lib/phonic.dart
@@ -92,9 +92,18 @@ export 'src/exceptions/tag_validation_exception.dart';
 export 'src/exceptions/unsupported_format_exception.dart';
 
 // Validators for input validation and form integration
-export 'src/validators/tag_validator.dart';
+export 'src/validators/album_validator.dart';
+export 'src/validators/artist_validator.dart';
+export 'src/validators/bpm_validator.dart';
+export 'src/validators/date_recorded_validator.dart';
+export 'src/validators/disc_number_validator.dart';
 export 'src/validators/rating_validator.dart';
+export 'src/validators/tag_validator.dart';
 export 'src/validators/tag_validators.dart';
+export 'src/validators/text_validator.dart';
+export 'src/validators/title_validator.dart';
+export 'src/validators/track_number_validator.dart';
+export 'src/validators/year_validator.dart';
 
 // Utils
 export 'src/utils/lazy_artwork_loader.dart';

--- a/lib/src/core/metadata_tag.dart
+++ b/lib/src/core/metadata_tag.dart
@@ -1,34 +1,35 @@
 import 'package:equatable/equatable.dart';
 
+import '../validators/rating_validator.dart';
 import 'artwork_data.dart';
 import 'tag_key.dart';
 import 'tag_provenance.dart';
 
+part '../tags/album_artist_tag.dart';
+part '../tags/album_tag.dart';
+part '../tags/artist_tag.dart';
+part '../tags/artwork_tag.dart';
+part '../tags/bpm_tag.dart';
+part '../tags/comment_tag.dart';
+part '../tags/composer_tag.dart';
+part '../tags/custom_tag.dart';
+part '../tags/date_recorded_tag.dart';
+part '../tags/disc_number_tag.dart';
+part '../tags/encoder_tag.dart';
+part '../tags/genre_tag.dart';
+part '../tags/grouping_tag.dart';
+part '../tags/isrc_tag.dart';
+part '../tags/lyrics_tag.dart';
+part '../tags/musical_key_tag.dart';
+part '../tags/rating_tag.dart';
 // Test helpers are included as a part file to allow extending the sealed class
 // This is necessary for comprehensive testing of the base class functionality
 // part '../../test/test_helpers/metadata_tag_test_helpers.dart'; // Disabled due to path issues
 
 // Concrete tag implementations
 part '../tags/title_tag.dart';
-part '../tags/artist_tag.dart';
-part '../tags/album_tag.dart';
-part '../tags/album_artist_tag.dart';
-part '../tags/genre_tag.dart';
-part '../tags/comment_tag.dart';
-part '../tags/grouping_tag.dart';
-part '../tags/composer_tag.dart';
-part '../tags/encoder_tag.dart';
-part '../tags/isrc_tag.dart';
-part '../tags/lyrics_tag.dart';
-part '../tags/musical_key_tag.dart';
 part '../tags/track_number_tag.dart';
-part '../tags/disc_number_tag.dart';
 part '../tags/year_tag.dart';
-part '../tags/date_recorded_tag.dart';
-part '../tags/bpm_tag.dart';
-part '../tags/rating_tag.dart';
-part '../tags/artwork_tag.dart';
-part '../tags/custom_tag.dart';
 
 /// Base sealed class for all metadata tags in the unified tagging system.
 ///

--- a/lib/src/core/metadata_tag.dart
+++ b/lib/src/core/metadata_tag.dart
@@ -1,6 +1,14 @@
 import 'package:equatable/equatable.dart';
 
+import '../validators/album_validator.dart';
+import '../validators/artist_validator.dart';
+import '../validators/bpm_validator.dart';
+import '../validators/date_recorded_validator.dart';
+import '../validators/disc_number_validator.dart';
 import '../validators/rating_validator.dart';
+import '../validators/title_validator.dart';
+import '../validators/track_number_validator.dart';
+import '../validators/year_validator.dart';
 import 'artwork_data.dart';
 import 'tag_key.dart';
 import 'tag_provenance.dart';

--- a/lib/src/tags/album_tag.dart
+++ b/lib/src/tags/album_tag.dart
@@ -37,7 +37,29 @@ part of '../core/metadata_tag.dart';
 /// The album value should be a non-empty string containing the album name.
 /// Different container formats may have length limitations that are handled
 /// automatically during encoding operations.
+///
+/// For validation and form integration, use [AlbumTag.validator]:
+/// ```dart
+/// // Pre-validate before creating tag
+/// if (AlbumTag.validator.validate(userInput) == null) {
+///   final tag = AlbumTag(userInput);
+/// }
+/// ```
 final class AlbumTag extends MetadataTag<String> {
+  /// Public validator for album tag values.
+  ///
+  /// This validator ensures that album values are not empty or whitespace-only,
+  /// making it useful for form validation where album is a required field.
+  ///
+  /// Example usage:
+  /// ```dart
+  /// // Pre-validate before creating tag
+  /// if (AlbumTag.validator.validate(userInput) == null) {
+  ///   final tag = AlbumTag(userInput);
+  /// }
+  /// ```
+  static const validator = AlbumValidator();
+
   /// Creates a new AlbumTag with the specified album value.
   ///
   /// @param value The name of the album or collection, must not be null

--- a/lib/src/tags/artist_tag.dart
+++ b/lib/src/tags/artist_tag.dart
@@ -37,7 +37,29 @@ part of '../core/metadata_tag.dart';
 /// The artist value should be a non-empty string containing the artist name.
 /// Different container formats may have length limitations that are handled
 /// automatically during encoding operations.
+///
+/// For validation and form integration, use [ArtistTag.validator]:
+/// ```dart
+/// // Pre-validate before creating tag
+/// if (ArtistTag.validator.validate(userInput) == null) {
+///   final tag = ArtistTag(userInput);
+/// }
+/// ```
 final class ArtistTag extends MetadataTag<String> {
+  /// Public validator for artist tag values.
+  ///
+  /// This validator ensures that artist values are not empty or whitespace-only,
+  /// making it useful for form validation where artist is a required field.
+  ///
+  /// Example usage:
+  /// ```dart
+  /// // Pre-validate before creating tag
+  /// if (ArtistTag.validator.validate(userInput) == null) {
+  ///   final tag = ArtistTag(userInput);
+  /// }
+  /// ```
+  static const validator = ArtistValidator();
+
   /// Creates a new ArtistTag with the specified artist value.
   ///
   /// @param value The name of the artist or performer, must not be null

--- a/lib/src/tags/bpm_tag.dart
+++ b/lib/src/tags/bpm_tag.dart
@@ -46,11 +46,25 @@ part of '../core/metadata_tag.dart';
 /// This range accommodates extremely slow ambient music through the fastest
 /// electronic genres while preventing obviously invalid tempo values.
 final class BpmTag extends MetadataTag<int> {
+  /// Validator for BPM values.
+  ///
+  /// This validator can be used to validate BPM values before creating
+  /// a [BpmTag] instance, or with form validation libraries.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Pre-validate before creating tag
+  /// if (BpmTag.validator.validate(userInput) == null) {
+  ///   final tag = BpmTag(userInput);
+  /// }
+  /// ```
+  static const validator = BpmValidator();
+
   /// The minimum valid BPM value (inclusive).
-  static const int minBpm = 1;
+  static const int minBpm = BpmValidator.min;
 
   /// The maximum valid BPM value (inclusive).
-  static const int maxBpm = 999;
+  static const int maxBpm = BpmValidator.max;
 
   /// Creates a new BpmTag with the specified BPM value.
   ///
@@ -68,26 +82,10 @@ final class BpmTag extends MetadataTag<int> {
     int value, {
     TagProvenance provenance = const TagProvenance.none(),
   }) : super(
-         value: _validateBpm(value),
+         value: validator.validateOrThrow(value),
          key: TagKey.bpm,
          provenance: provenance,
        );
-
-  /// Validates that the BPM is within the acceptable range.
-  ///
-  /// @param value The BPM to validate
-  /// @returns The validated BPM
-  /// @throws ArgumentError if the BPM is not between 1 and 999 (inclusive)
-  static int _validateBpm(int value) {
-    if (value < minBpm || value > maxBpm) {
-      throw ArgumentError.value(
-        value,
-        'value',
-        'BPM must be between $minBpm and $maxBpm (inclusive)',
-      );
-    }
-    return value;
-  }
 
   /// Creates a new BpmTag instance with updated provenance information.
   ///

--- a/lib/src/tags/date_recorded_tag.dart
+++ b/lib/src/tags/date_recorded_tag.dart
@@ -57,24 +57,29 @@ part of '../core/metadata_tag.dart';
 /// The date value must be a valid ISO-8601 formatted string. Invalid formats
 /// will cause an ArgumentError to be thrown during construction. This ensures
 /// consistent date handling across different container formats and platforms.
+///
+/// For validation and form integration, use [DateRecordedTag.validator]:
+/// ```dart
+/// // Pre-validate before creating tag
+/// if (DateRecordedTag.validator.validate(userInput) == null) {
+///   final tag = DateRecordedTag(userInput);
+/// }
+/// ```
 final class DateRecordedTag extends MetadataTag<String> {
-  /// Regular expression for validating ISO-8601 date formats.
+  /// Public validator for date recorded tag values.
   ///
-  /// Supports the following formats:
-  /// - YYYY (year only)
-  /// - YYYY-MM (year and month)
-  /// - YYYY-MM-DD (full date)
-  /// - YYYY-MM-DDTHH:MM:SS (date and time)
-  /// - YYYY-MM-DDTHH:MM:SSZ (date and time with UTC timezone)
-  /// - YYYY-MM-DDTHH:MM:SS±HH:MM (date and time with timezone offset)
-  static final RegExp _iso8601Pattern = RegExp(
-    r'^(\d{4})' // Year (YYYY)
-    r'(?:-(\d{2}))?' // Optional month (-MM)
-    r'(?:-(\d{2}))?' // Optional day (-DD)
-    r'(?:T(\d{2}):(\d{2}):(\d{2}))?' // Optional time (THH:MM:SS)
-    r'(?:\.(\d{1,3}))?' // Optional milliseconds (.SSS)
-    r'(?:(Z)|([+-]\d{2}):?(\d{2}))?$', // Optional timezone (Z or ±HH:MM)
-  );
+  /// This validator can be used to pre-validate user input before creating
+  /// a DateRecordedTag instance, or integrated with form validation libraries
+  /// like reactive_forms.
+  ///
+  /// Example usage:
+  /// ```dart
+  /// // Pre-validate before creating tag
+  /// if (DateRecordedTag.validator.validate(userInput) == null) {
+  ///   final tag = DateRecordedTag(userInput);
+  /// }
+  /// ```
+  static const validator = DateRecordedValidator();
 
   /// Creates a new DateRecordedTag with the specified ISO-8601 date.
   ///
@@ -92,145 +97,10 @@ final class DateRecordedTag extends MetadataTag<String> {
     String value, {
     TagProvenance provenance = const TagProvenance.none(),
   }) : super(
-         value: _validateIso8601Date(value),
+         value: validator.validateOrThrow(value),
          key: TagKey.dateRecorded,
          provenance: provenance,
        );
-
-  /// Validates that the date string is in valid ISO-8601 format.
-  ///
-  /// @param value The date string to validate
-  /// @returns The validated date string
-  /// @throws ArgumentError if the date is not in valid ISO-8601 format
-  static String _validateIso8601Date(String value) {
-    if (value.trim().isEmpty) {
-      throw ArgumentError.value(
-        value,
-        'value',
-        'Date recorded cannot be empty',
-      );
-    }
-
-    final trimmedValue = value.trim();
-
-    if (!_iso8601Pattern.hasMatch(trimmedValue)) {
-      throw ArgumentError.value(
-        value,
-        'value',
-        'Date must be in ISO-8601 format (e.g., "2023", "2023-03-15", "2023-03-15T14:30:00Z")',
-      );
-    }
-
-    // Additional validation for date components
-    final match = _iso8601Pattern.firstMatch(trimmedValue)!;
-    final year = int.parse(match.group(1)!);
-    final monthStr = match.group(2);
-    final dayStr = match.group(3);
-    final hourStr = match.group(4);
-    final minuteStr = match.group(5);
-    final secondStr = match.group(6);
-
-    // Validate year range (reasonable range for audio recordings)
-    if (year < 1900 || year > 2100) {
-      throw ArgumentError.value(
-        value,
-        'value',
-        'Year must be between 1900 and 2100 (inclusive)',
-      );
-    }
-
-    // Validate month if present
-    if (monthStr != null) {
-      final month = int.parse(monthStr);
-      if (month < 1 || month > 12) {
-        throw ArgumentError.value(
-          value,
-          'value',
-          'Month must be between 01 and 12',
-        );
-      }
-    }
-
-    // Validate day if present
-    if (dayStr != null && monthStr != null) {
-      final month = int.parse(monthStr);
-      final day = int.parse(dayStr);
-
-      if (day < 1 || day > _getDaysInMonth(year, month)) {
-        throw ArgumentError.value(
-          value,
-          'value',
-          'Day $day is not valid for year $year month $month',
-        );
-      }
-    }
-
-    // Validate time components if present
-    if (hourStr != null) {
-      final hour = int.parse(hourStr);
-      if (hour < 0 || hour > 23) {
-        throw ArgumentError.value(
-          value,
-          'value',
-          'Hour must be between 00 and 23',
-        );
-      }
-    }
-
-    if (minuteStr != null) {
-      final minute = int.parse(minuteStr);
-      if (minute < 0 || minute > 59) {
-        throw ArgumentError.value(
-          value,
-          'value',
-          'Minute must be between 00 and 59',
-        );
-      }
-    }
-
-    if (secondStr != null) {
-      final second = int.parse(secondStr);
-      if (second < 0 || second > 59) {
-        throw ArgumentError.value(
-          value,
-          'value',
-          'Second must be between 00 and 59',
-        );
-      }
-    }
-
-    return trimmedValue;
-  }
-
-  /// Returns the number of days in the specified month and year.
-  ///
-  /// Accounts for leap years when calculating February days.
-  static int _getDaysInMonth(int year, int month) {
-    switch (month) {
-      case 1:
-      case 3:
-      case 5:
-      case 7:
-      case 8:
-      case 10:
-      case 12:
-        return 31;
-      case 4:
-      case 6:
-      case 9:
-      case 11:
-        return 30;
-      case 2:
-        return _isLeapYear(year) ? 29 : 28;
-      default:
-        return 31; // Should never reach here due to month validation
-    }
-  }
-
-  /// Determines if the specified year is a leap year.
-  static bool _isLeapYear(int year) {
-    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
-  }
 
   /// Creates a new DateRecordedTag instance with updated provenance information.
   ///

--- a/lib/src/tags/disc_number_tag.dart
+++ b/lib/src/tags/disc_number_tag.dart
@@ -44,6 +44,20 @@ part of '../core/metadata_tag.dart';
 /// Different container formats may have different maximum values, but
 /// validation is handled during encoding.
 final class DiscNumberTag extends MetadataTag<int> {
+  /// Validator for disc number values.
+  ///
+  /// This validator can be used to validate disc number values before creating
+  /// a [DiscNumberTag] instance, or with form validation libraries.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Pre-validate before creating tag
+  /// if (DiscNumberTag.validator.validate(userInput) == null) {
+  ///   final tag = DiscNumberTag(userInput);
+  /// }
+  /// ```
+  static const validator = DiscNumberValidator();
+
   /// Creates a new DiscNumberTag with the specified disc number.
   ///
   /// @param value The disc number within the set, must be greater than 0
@@ -59,26 +73,10 @@ final class DiscNumberTag extends MetadataTag<int> {
     int value, {
     TagProvenance provenance = const TagProvenance.none(),
   }) : super(
-         value: _validateDiscNumber(value),
+         value: validator.validateOrThrow(value),
          key: TagKey.discNumber,
          provenance: provenance,
        );
-
-  /// Validates that the disc number is greater than 0.
-  ///
-  /// @param value The disc number to validate
-  /// @returns The validated disc number
-  /// @throws ArgumentError if the disc number is not greater than 0
-  static int _validateDiscNumber(int value) {
-    if (value <= 0) {
-      throw ArgumentError.value(
-        value,
-        'value',
-        'Disc number must be greater than 0',
-      );
-    }
-    return value;
-  }
 
   /// Creates a new DiscNumberTag instance with updated provenance information.
   ///

--- a/lib/src/tags/rating_tag.dart
+++ b/lib/src/tags/rating_tag.dart
@@ -39,6 +39,12 @@ part of '../core/metadata_tag.dart';
 /// final updatedTag = ratingTag.withProvenance(
 ///   TagProvenance(ContainerKind.vorbis, '', TagConfidence.certain),
 /// );
+///
+/// // Validate rating before creating tag
+/// final error = RatingTag.validator.validate(150);
+/// if (error != null) {
+///   print('Invalid rating: $error');
+/// }
 /// ```
 ///
 /// The rating value must be between 0 and 100 (inclusive). Values outside
@@ -46,11 +52,33 @@ part of '../core/metadata_tag.dart';
 /// This range provides a standardized percentage-based rating system that
 /// can be easily converted to format-specific scales as needed.
 final class RatingTag extends MetadataTag<int> {
+  /// Validator for rating values.
+  ///
+  /// This validator can be used to validate rating values before creating
+  /// a [RatingTag] instance, or with form validation libraries like
+  /// reactive_forms.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Pre-validate before creating tag
+  /// if (RatingTag.validator.validate(userInput) == null) {
+  ///   final tag = RatingTag(userInput);
+  /// }
+  ///
+  /// // Use with reactive_forms
+  /// final control = FormControl<int>(
+  ///   validators: [
+  ///     Validators.delegate((c) => RatingTag.validator.validate(c.value)),
+  ///   ],
+  /// );
+  /// ```
+  static const validator = RatingValidator();
+
   /// The minimum valid rating value (inclusive).
-  static const int minRating = 0;
+  static const int minRating = RatingValidator.min;
 
   /// The maximum valid rating value (inclusive).
-  static const int maxRating = 100;
+  static const int maxRating = RatingValidator.max;
 
   /// Creates a new RatingTag with the specified rating value.
   ///
@@ -70,26 +98,10 @@ final class RatingTag extends MetadataTag<int> {
     int value, {
     TagProvenance provenance = const TagProvenance.none(),
   }) : super(
-         value: _validateRating(value),
+         value: validator.validateOrThrow(value),
          key: TagKey.rating,
          provenance: provenance,
        );
-
-  /// Validates that the rating is within the acceptable range.
-  ///
-  /// @param value The rating to validate
-  /// @returns The validated rating
-  /// @throws ArgumentError if the rating is not between 0 and 100 (inclusive)
-  static int _validateRating(int value) {
-    if (value < minRating || value > maxRating) {
-      throw ArgumentError.value(
-        value,
-        'value',
-        'Rating must be between $minRating and $maxRating (inclusive)',
-      );
-    }
-    return value;
-  }
 
   /// Creates a new RatingTag instance with updated provenance information.
   ///

--- a/lib/src/tags/title_tag.dart
+++ b/lib/src/tags/title_tag.dart
@@ -36,7 +36,29 @@ part of '../core/metadata_tag.dart';
 /// The title value should be a non-empty string containing the track name.
 /// Different container formats may have length limitations that are handled
 /// automatically during encoding operations.
+///
+/// For validation and form integration, use [TitleTag.validator]:
+/// ```dart
+/// // Pre-validate before creating tag
+/// if (TitleTag.validator.validate(userInput) == null) {
+///   final tag = TitleTag(userInput);
+/// }
+/// ```
 final class TitleTag extends MetadataTag<String> {
+  /// Public validator for title tag values.
+  ///
+  /// This validator ensures that title values are not empty or whitespace-only,
+  /// making it useful for form validation where title is a required field.
+  ///
+  /// Example usage:
+  /// ```dart
+  /// // Pre-validate before creating tag
+  /// if (TitleTag.validator.validate(userInput) == null) {
+  ///   final tag = TitleTag(userInput);
+  /// }
+  /// ```
+  static const validator = TitleValidator();
+
   /// Creates a new TitleTag with the specified title value.
   ///
   /// @param value The title or name of the track, must not be null

--- a/lib/src/tags/track_number_tag.dart
+++ b/lib/src/tags/track_number_tag.dart
@@ -43,6 +43,20 @@ part of '../core/metadata_tag.dart';
 /// Different container formats may have different maximum values (e.g.,
 /// ID3v1 supports 1-255), but validation is handled during encoding.
 final class TrackNumberTag extends MetadataTag<int> {
+  /// Validator for track number values.
+  ///
+  /// This validator can be used to validate track number values before creating
+  /// a [TrackNumberTag] instance, or with form validation libraries.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Pre-validate before creating tag
+  /// if (TrackNumberTag.validator.validate(userInput) == null) {
+  ///   final tag = TrackNumberTag(userInput);
+  /// }
+  /// ```
+  static const validator = TrackNumberValidator();
+
   /// Creates a new TrackNumberTag with the specified track number.
   ///
   /// @param value The track number within the album, must be greater than 0
@@ -58,26 +72,10 @@ final class TrackNumberTag extends MetadataTag<int> {
     int value, {
     TagProvenance provenance = const TagProvenance.none(),
   }) : super(
-         value: _validateTrackNumber(value),
+         value: validator.validateOrThrow(value),
          key: TagKey.trackNumber,
          provenance: provenance,
        );
-
-  /// Validates that the track number is greater than 0.
-  ///
-  /// @param value The track number to validate
-  /// @returns The validated track number
-  /// @throws ArgumentError if the track number is not greater than 0
-  static int _validateTrackNumber(int value) {
-    if (value <= 0) {
-      throw ArgumentError.value(
-        value,
-        'value',
-        'Track number must be greater than 0',
-      );
-    }
-    return value;
-  }
 
   /// Creates a new TrackNumberTag instance with updated provenance information.
   ///

--- a/lib/src/tags/year_tag.dart
+++ b/lib/src/tags/year_tag.dart
@@ -44,11 +44,25 @@ part of '../core/metadata_tag.dart';
 /// This range accommodates the earliest commercial recordings through
 /// reasonable future releases while preventing obviously invalid dates.
 final class YearTag extends MetadataTag<int> {
+  /// Validator for year values.
+  ///
+  /// This validator can be used to validate year values before creating
+  /// a [YearTag] instance, or with form validation libraries.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Pre-validate before creating tag
+  /// if (YearTag.validator.validate(userInput) == null) {
+  ///   final tag = YearTag(userInput);
+  /// }
+  /// ```
+  static const validator = YearValidator();
+
   /// The minimum valid year value (inclusive).
-  static const int minYear = 1900;
+  static const int minYear = YearValidator.min;
 
   /// The maximum valid year value (inclusive).
-  static const int maxYear = 2100;
+  static const int maxYear = YearValidator.max;
 
   /// Creates a new YearTag with the specified year.
   ///
@@ -66,26 +80,10 @@ final class YearTag extends MetadataTag<int> {
     int value, {
     TagProvenance provenance = const TagProvenance.none(),
   }) : super(
-         value: _validateYear(value),
+         value: validator.validateOrThrow(value),
          key: TagKey.year,
          provenance: provenance,
        );
-
-  /// Validates that the year is within the acceptable range.
-  ///
-  /// @param value The year to validate
-  /// @returns The validated year
-  /// @throws ArgumentError if the year is not between 1900 and 2100 (inclusive)
-  static int _validateYear(int value) {
-    if (value < minYear || value > maxYear) {
-      throw ArgumentError.value(
-        value,
-        'value',
-        'Year must be between $minYear and $maxYear (inclusive)',
-      );
-    }
-    return value;
-  }
 
   /// Creates a new YearTag instance with updated provenance information.
   ///

--- a/lib/src/validators/album_validator.dart
+++ b/lib/src/validators/album_validator.dart
@@ -1,0 +1,27 @@
+import 'text_validator.dart';
+
+/// Validator for album tag values.
+///
+/// This validator ensures that album values are not empty or whitespace-only.
+///
+/// Error keys:
+/// - `empty`: Value is empty or contains only whitespace
+///
+/// Example usage:
+/// ```dart
+/// const validator = AlbumValidator();
+///
+/// final error = validator.validate('Abbey Road');  // null (valid)
+/// final error2 = validator.validate('');           // {empty: {...}}
+/// ```
+final class AlbumValidator extends TextValidator {
+  /// Creates a new album validator.
+  const AlbumValidator() : super(fieldName: 'Album');
+
+  /// Checks if a value is a valid album.
+  ///
+  /// Returns `true` if the value is valid, `false` otherwise.
+  static bool isValid(String? value) {
+    return const AlbumValidator().validate(value) == null;
+  }
+}

--- a/lib/src/validators/artist_validator.dart
+++ b/lib/src/validators/artist_validator.dart
@@ -1,0 +1,27 @@
+import 'text_validator.dart';
+
+/// Validator for artist tag values.
+///
+/// This validator ensures that artist values are not empty or whitespace-only.
+///
+/// Error keys:
+/// - `empty`: Value is empty or contains only whitespace
+///
+/// Example usage:
+/// ```dart
+/// const validator = ArtistValidator();
+///
+/// final error = validator.validate('The Beatles');  // null (valid)
+/// final error2 = validator.validate('');            // {empty: {...}}
+/// ```
+final class ArtistValidator extends TextValidator {
+  /// Creates a new artist validator.
+  const ArtistValidator() : super(fieldName: 'Artist');
+
+  /// Checks if a value is a valid artist.
+  ///
+  /// Returns `true` if the value is valid, `false` otherwise.
+  static bool isValid(String? value) {
+    return const ArtistValidator().validate(value) == null;
+  }
+}

--- a/lib/src/validators/bpm_validator.dart
+++ b/lib/src/validators/bpm_validator.dart
@@ -1,0 +1,66 @@
+import 'tag_validator.dart';
+
+/// Validator for BPM (beats per minute) tag values.
+///
+/// This validator ensures that BPM values are within the valid range
+/// of 1-999 (inclusive), representing realistic musical tempos from
+/// very slow ballads to extremely fast electronic music.
+///
+/// Error keys:
+/// - `outOfRange`: Value is outside the valid range (1-999)
+///
+/// Example usage:
+/// ```dart
+/// const validator = BpmValidator();
+///
+/// final error = validator.validate(120);  // null (valid)
+/// final error2 = validator.validate(0);   // {outOfRange: {...}}
+/// final error3 = validator.validate(1000); // {outOfRange: {...}}
+/// ```
+final class BpmValidator extends TagValidator<int> {
+  /// The minimum valid BPM value (inclusive).
+  static const int min = 1;
+
+  /// The maximum valid BPM value (inclusive).
+  static const int max = 999;
+
+  /// Error key for out-of-range values.
+  static const String outOfRangeError = 'outOfRange';
+
+  /// Creates a new BPM validator.
+  const BpmValidator();
+
+  @override
+  Map<String, dynamic>? validate(int? value) {
+    // Null values are allowed (optional field)
+    if (value == null) return null;
+
+    // Check range
+    if (value < min || value > max) {
+      return {
+        outOfRangeError: {
+          'min': min,
+          'max': max,
+          'actual': value,
+        },
+      };
+    }
+
+    return null;
+  }
+
+  @override
+  String formatErrorMessage(Map<String, dynamic> error) {
+    if (error.containsKey(outOfRangeError)) {
+      return 'BPM must be between $min and $max (inclusive)';
+    }
+    return 'Invalid BPM value';
+  }
+
+  /// Checks if a value is within the valid BPM range.
+  ///
+  /// Returns `true` if the value is valid, `false` otherwise.
+  static bool isValid(int? value) {
+    return const BpmValidator().validate(value) == null;
+  }
+}

--- a/lib/src/validators/date_recorded_validator.dart
+++ b/lib/src/validators/date_recorded_validator.dart
@@ -1,0 +1,280 @@
+import 'tag_validator.dart';
+
+/// Validator for date recorded tag values in ISO-8601 format.
+///
+/// This validator ensures that date values conform to ISO-8601 format
+/// with various levels of precision (year-only, year-month, full date,
+/// date with time and timezone). It also validates date component ranges
+/// and logical consistency (e.g., valid day for the given month/year).
+///
+/// Supported formats:
+/// - Year only: "2023"
+/// - Year-month: "2023-03"
+/// - Full date: "2023-03-15"
+/// - Date with time: "2023-03-15T14:30:00"
+/// - Date with timezone: "2023-03-15T14:30:00Z"
+/// - Date with offset: "2023-03-15T14:30:00+02:00"
+///
+/// Error keys:
+/// - `empty`: Value is empty or contains only whitespace
+/// - `invalidFormat`: Value doesn't match ISO-8601 format
+/// - `yearOutOfRange`: Year is outside 1900-2100 range
+/// - `invalidMonth`: Month is not between 01-12
+/// - `invalidDay`: Day is not valid for the given month/year
+/// - `invalidHour`: Hour is not between 00-23
+/// - `invalidMinute`: Minute is not between 00-59
+/// - `invalidSecond`: Second is not between 00-59
+///
+/// Example usage:
+/// ```dart
+/// const validator = DateRecordedValidator();
+///
+/// final error = validator.validate('2023-03-15');  // null (valid)
+/// final error2 = validator.validate('');           // {empty: {...}}
+/// final error3 = validator.validate('March 2023'); // {invalidFormat: {...}}
+/// final error4 = validator.validate('2023-13-01'); // {invalidMonth: {...}}
+/// ```
+final class DateRecordedValidator extends TagValidator<String> {
+  /// Regular expression for validating ISO-8601 date formats.
+  static final RegExp _iso8601Pattern = RegExp(
+    r'^(\d{4})' // Year (YYYY)
+    r'(?:-(\d{2}))?' // Optional month (-MM)
+    r'(?:-(\d{2}))?' // Optional day (-DD)
+    r'(?:T(\d{2}):(\d{2}):(\d{2}))?' // Optional time (THH:MM:SS)
+    r'(?:\.(\d{1,3}))?' // Optional milliseconds (.SSS)
+    r'(?:(Z)|([+-]\d{2}):?(\d{2}))?$', // Optional timezone (Z or ±HH:MM)
+  );
+
+  /// The minimum valid year value (inclusive).
+  static const int minYear = 1900;
+
+  /// The maximum valid year value (inclusive).
+  static const int maxYear = 2100;
+
+  /// Error key for empty values.
+  static const String emptyError = 'empty';
+
+  /// Error key for invalid format.
+  static const String invalidFormatError = 'invalidFormat';
+
+  /// Error key for year out of range.
+  static const String yearOutOfRangeError = 'yearOutOfRange';
+
+  /// Error key for invalid month.
+  static const String invalidMonthError = 'invalidMonth';
+
+  /// Error key for invalid day.
+  static const String invalidDayError = 'invalidDay';
+
+  /// Error key for invalid hour.
+  static const String invalidHourError = 'invalidHour';
+
+  /// Error key for invalid minute.
+  static const String invalidMinuteError = 'invalidMinute';
+
+  /// Error key for invalid second.
+  static const String invalidSecondError = 'invalidSecond';
+
+  /// Creates a new date recorded validator.
+  const DateRecordedValidator();
+
+  @override
+  Map<String, dynamic>? validate(String? value) {
+    // Null values are allowed (optional field)
+    if (value == null) return null;
+
+    // Check for empty string
+    if (value.trim().isEmpty) {
+      return {
+        emptyError: {
+          'actual': value,
+        },
+      };
+    }
+
+    final trimmedValue = value.trim();
+
+    // Check format
+    if (!_iso8601Pattern.hasMatch(trimmedValue)) {
+      return {
+        invalidFormatError: {
+          'actual': value,
+          'expected': 'ISO-8601 format (e.g., "2023", "2023-03-15", "2023-03-15T14:30:00Z")',
+        },
+      };
+    }
+
+    // Parse and validate date components
+    final match = _iso8601Pattern.firstMatch(trimmedValue)!;
+    final year = int.parse(match.group(1)!);
+    final monthStr = match.group(2);
+    final dayStr = match.group(3);
+    final hourStr = match.group(4);
+    final minuteStr = match.group(5);
+    final secondStr = match.group(6);
+
+    // Validate year range
+    if (year < minYear || year > maxYear) {
+      return {
+        yearOutOfRangeError: {
+          'min': minYear,
+          'max': maxYear,
+          'actual': year,
+        },
+      };
+    }
+
+    // Validate month if present
+    if (monthStr != null) {
+      final month = int.parse(monthStr);
+      if (month < 1 || month > 12) {
+        return {
+          invalidMonthError: {
+            'actual': month,
+            'min': 1,
+            'max': 12,
+          },
+        };
+      }
+
+      // Validate day if present
+      if (dayStr != null) {
+        final day = int.parse(dayStr);
+        final maxDays = _getDaysInMonth(year, month);
+
+        if (day < 1 || day > maxDays) {
+          return {
+            invalidDayError: {
+              'actual': day,
+              'max': maxDays,
+              'year': year,
+              'month': month,
+            },
+          };
+        }
+      }
+    }
+
+    // Validate time components if present
+    if (hourStr != null) {
+      final hour = int.parse(hourStr);
+      if (hour < 0 || hour > 23) {
+        return {
+          invalidHourError: {
+            'actual': hour,
+            'min': 0,
+            'max': 23,
+          },
+        };
+      }
+    }
+
+    if (minuteStr != null) {
+      final minute = int.parse(minuteStr);
+      if (minute < 0 || minute > 59) {
+        return {
+          invalidMinuteError: {
+            'actual': minute,
+            'min': 0,
+            'max': 59,
+          },
+        };
+      }
+    }
+
+    if (secondStr != null) {
+      final second = int.parse(secondStr);
+      if (second < 0 || second > 59) {
+        return {
+          invalidSecondError: {
+            'actual': second,
+            'min': 0,
+            'max': 59,
+          },
+        };
+      }
+    }
+
+    return null;
+  }
+
+  @override
+  String validateOrThrow(String value) {
+    final error = validate(value);
+    if (error != null) {
+      throw ArgumentError(formatErrorMessage(error));
+    }
+    // Return trimmed value (normalized)
+    return value.trim();
+  }
+
+  @override
+  String formatErrorMessage(Map<String, dynamic> error) {
+    if (error.containsKey(emptyError)) {
+      return 'Date recorded cannot be empty';
+    }
+    if (error.containsKey(invalidFormatError)) {
+      return 'Date must be in ISO-8601 format (e.g., "2023", "2023-03-15", "2023-03-15T14:30:00Z")';
+    }
+    if (error.containsKey(yearOutOfRangeError)) {
+      return 'Year must be between $minYear and $maxYear (inclusive)';
+    }
+    if (error.containsKey(invalidMonthError)) {
+      return 'Month must be between 01 and 12';
+    }
+    if (error.containsKey(invalidDayError)) {
+      final details = error[invalidDayError] as Map<String, dynamic>;
+      final year = details['year'];
+      final month = details['month'];
+      final day = details['actual'];
+      return 'Day $day is not valid for year $year month $month';
+    }
+    if (error.containsKey(invalidHourError)) {
+      return 'Hour must be between 00 and 23';
+    }
+    if (error.containsKey(invalidMinuteError)) {
+      return 'Minute must be between 00 and 59';
+    }
+    if (error.containsKey(invalidSecondError)) {
+      return 'Second must be between 00 and 59';
+    }
+    return 'Invalid date recorded value';
+  }
+
+  /// Returns the number of days in the specified month and year.
+  ///
+  /// Accounts for leap years when calculating February days.
+  static int _getDaysInMonth(int year, int month) {
+    switch (month) {
+      case 1:
+      case 3:
+      case 5:
+      case 7:
+      case 8:
+      case 10:
+      case 12:
+        return 31;
+      case 4:
+      case 6:
+      case 9:
+      case 11:
+        return 30;
+      case 2:
+        return _isLeapYear(year) ? 29 : 28;
+      default:
+        return 31; // Should never reach here due to month validation
+    }
+  }
+
+  /// Determines if the specified year is a leap year.
+  static bool _isLeapYear(int year) {
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+  }
+
+  /// Checks if a value is a valid ISO-8601 date.
+  ///
+  /// Returns `true` if the value is valid, `false` otherwise.
+  static bool isValid(String? value) {
+    return const DateRecordedValidator().validate(value) == null;
+  }
+}

--- a/lib/src/validators/disc_number_validator.dart
+++ b/lib/src/validators/disc_number_validator.dart
@@ -1,0 +1,60 @@
+import 'tag_validator.dart';
+
+/// Validator for disc number tag values.
+///
+/// This validator ensures that disc number values are positive integers
+/// greater than 0, representing the disc's position within a multi-disc set.
+///
+/// Error keys:
+/// - `notPositive`: Value is not a positive integer (must be > 0)
+///
+/// Example usage:
+/// ```dart
+/// const validator = DiscNumberValidator();
+///
+/// final error = validator.validate(2);   // null (valid)
+/// final error2 = validator.validate(0);  // {notPositive: {...}}
+/// final error3 = validator.validate(-1); // {notPositive: {...}}
+/// ```
+final class DiscNumberValidator extends TagValidator<int> {
+  /// The minimum valid disc number value (exclusive).
+  static const int min = 0;
+
+  /// Error key for non-positive values.
+  static const String notPositiveError = 'notPositive';
+
+  /// Creates a new disc number validator.
+  const DiscNumberValidator();
+
+  @override
+  Map<String, dynamic>? validate(int? value) {
+    // Null values are allowed (optional field)
+    if (value == null) return null;
+
+    // Check if positive
+    if (value <= min) {
+      return {
+        notPositiveError: {
+          'actual': value,
+        },
+      };
+    }
+
+    return null;
+  }
+
+  @override
+  String formatErrorMessage(Map<String, dynamic> error) {
+    if (error.containsKey(notPositiveError)) {
+      return 'Disc number must be greater than 0';
+    }
+    return 'Invalid disc number';
+  }
+
+  /// Checks if a value is a valid disc number.
+  ///
+  /// Returns `true` if the value is valid, `false` otherwise.
+  static bool isValid(int? value) {
+    return const DiscNumberValidator().validate(value) == null;
+  }
+}

--- a/lib/src/validators/rating_validator.dart
+++ b/lib/src/validators/rating_validator.dart
@@ -1,0 +1,103 @@
+import 'package:phonic/src/core/metadata_tag.dart';
+
+import 'tag_validator.dart';
+
+/// Validator for rating tag values.
+///
+/// This validator ensures that rating values are within the valid range
+/// of 0-100 (inclusive), representing a percentage-based rating scale.
+///
+/// The validator can be used in multiple contexts:
+/// 1. Internally by [RatingTag] constructor for validation
+/// 2. Externally by users for pre-validation before creating tags
+/// 3. With form validation libraries like reactive_forms
+///
+/// Error keys:
+/// - `outOfRange`: Value is outside the valid range (0-100)
+///
+/// Example usage:
+/// ```dart
+/// // Direct validation
+/// const validator = RatingValidator();
+/// final error = validator.validate(150);
+/// if (error != null) {
+///   print('Invalid: ${error}'); // {outOfRange: {min: 0, max: 100, actual: 150}}
+/// }
+///
+/// // With reactive_forms
+/// final control = FormControl<int>(
+///   validators: [
+///     Validators.delegate((c) => validator.validate(c.value)),
+///   ],
+/// );
+///
+/// // In a TextField with precise error handling
+/// ReactiveTextField<int>(
+///   formControlName: 'rating',
+///   validationMessages: {
+///     'outOfRange': (error) {
+///       final e = error as Map;
+///       return 'Rating must be between ${e['min']} and ${e['max']}, you entered ${e['actual']}';
+///     },
+///   },
+/// );
+/// ```
+class RatingValidator extends TagValidator<int> {
+  /// The minimum valid rating value (inclusive).
+  static const int min = 0;
+
+  /// The maximum valid rating value (inclusive).
+  static const int max = 100;
+
+  /// Error key for out-of-range values.
+  static const String outOfRangeError = 'outOfRange';
+
+  /// Creates a new rating validator.
+  const RatingValidator();
+
+  @override
+  Map<String, dynamic>? validate(int? value) {
+    // Null values are considered valid (use with required validator if needed)
+    if (value == null) {
+      return null;
+    }
+
+    if (value < min || value > max) {
+      return {
+        outOfRangeError: {
+          'min': min,
+          'max': max,
+          'actual': value,
+        },
+      };
+    }
+
+    return null;
+  }
+
+  @override
+  String formatErrorMessage(Map<String, dynamic> error) {
+    final data = error[outOfRangeError] as Map<String, dynamic>;
+    return 'Rating must be between ${data['min']} and ${data['max']} (inclusive)';
+  }
+
+  /// Checks if a value is within the valid rating range.
+  ///
+  /// This is a convenience method for quick boolean checks.
+  ///
+  /// Parameters:
+  /// - [value]: The value to check
+  ///
+  /// Returns:
+  /// - `true` if the value is valid, `false` otherwise
+  ///
+  /// Example:
+  /// ```dart
+  /// if (RatingValidator.isValid(85)) {
+  ///   print('Valid rating');
+  /// }
+  /// ```
+  static bool isValid(int? value) {
+    return const RatingValidator().validate(value) == null;
+  }
+}

--- a/lib/src/validators/tag_validator.dart
+++ b/lib/src/validators/tag_validator.dart
@@ -1,0 +1,107 @@
+/// Base class for all tag validators.
+///
+/// This abstract class provides a foundation for implementing validators
+/// that can be used both internally by tag constructors and externally
+/// by users for input validation (e.g., with reactive_forms).
+///
+/// Validators return `null` for valid values and a `Map<String, dynamic>`
+/// containing error information for invalid values.
+///
+/// Example usage:
+/// ```dart
+/// final validator = RatingValidator();
+///
+/// // Check if a value is valid
+/// final error = validator.validate(150);
+/// if (error != null) {
+///   print('Validation failed: ${error}');
+/// }
+///
+/// // Validate and throw on error (used internally by tags)
+/// try {
+///   final value = validator.validateOrThrow(150);
+/// } on ArgumentError catch (e) {
+///   print('Invalid rating: ${e.message}');
+/// }
+///
+/// // Use with reactive_forms
+/// final control = FormControl<int>(
+///   validators: [
+///     Validators.delegate((c) => validator.validate(c.value)),
+///   ],
+/// );
+/// ```
+abstract class TagValidator<T> {
+  /// Creates a new tag validator.
+  const TagValidator();
+
+  /// Validates the given value.
+  ///
+  /// Returns `null` if the value is valid, or a `Map<String, dynamic>`
+  /// containing error information if the value is invalid.
+  ///
+  /// The error map typically has a single key identifying the validation
+  /// error type, with a value containing detailed error information such
+  /// as constraints and the actual value.
+  ///
+  /// Example error format:
+  /// ```dart
+  /// {
+  ///   'outOfRange': {
+  ///     'min': 0,
+  ///     'max': 100,
+  ///     'actual': 150,
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Parameters:
+  /// - [value]: The value to validate. Can be `null`.
+  ///
+  /// Returns:
+  /// - `null` if validation passes
+  /// - `Map<String, dynamic>` with error details if validation fails
+  Map<String, dynamic>? validate(T? value);
+
+  /// Validates the value and throws an [ArgumentError] if invalid.
+  ///
+  /// This method is used internally by tag constructors to ensure
+  /// validation while throwing exceptions for invalid values.
+  ///
+  /// Parameters:
+  /// - [value]: The value to validate. Must not be `null`.
+  ///
+  /// Returns:
+  /// - The validated value if validation passes
+  ///
+  /// Throws:
+  /// - [ArgumentError] if validation fails
+  ///
+  /// Example:
+  /// ```dart
+  /// final validator = RatingValidator();
+  /// final validatedRating = validator.validateOrThrow(85);
+  /// ```
+  T validateOrThrow(T value) {
+    final error = validate(value);
+    if (error != null) {
+      throw ArgumentError(formatErrorMessage(error));
+    }
+    return value;
+  }
+
+  /// Formats the error map into a human-readable error message.
+  ///
+  /// This method is called by [validateOrThrow] to create the error
+  /// message for the [ArgumentError].
+  ///
+  /// Subclasses should override this method to provide custom error
+  /// messages that are appropriate for their validation rules.
+  ///
+  /// Parameters:
+  /// - [error]: The error map returned by [validate]
+  ///
+  /// Returns:
+  /// - A human-readable error message string
+  String formatErrorMessage(Map<String, dynamic> error);
+}

--- a/lib/src/validators/tag_validators.dart
+++ b/lib/src/validators/tag_validators.dart
@@ -1,4 +1,12 @@
+import 'album_validator.dart';
+import 'artist_validator.dart';
+import 'bpm_validator.dart';
+import 'date_recorded_validator.dart';
+import 'disc_number_validator.dart';
 import 'rating_validator.dart';
+import 'title_validator.dart';
+import 'track_number_validator.dart';
+import 'year_validator.dart';
 
 /// Convenience class providing access to all tag validators.
 ///
@@ -32,23 +40,30 @@ class TagValidators {
   // Private constructor to prevent instantiation
   TagValidators._();
 
+  /// Validator for title tag values (non-empty).
+  static const title = TitleValidator();
+
+  /// Validator for artist tag values (non-empty).
+  static const artist = ArtistValidator();
+
+  /// Validator for album tag values (non-empty).
+  static const album = AlbumValidator();
+
   /// Validator for rating tag values (0-100 range).
-  ///
-  /// Example:
-  /// ```dart
-  /// final error = TagValidators.rating.validate(150);
-  /// if (error != null) {
-  ///   // Handle validation error
-  ///   final data = error['outOfRange'];
-  ///   print('Rating must be ${data['min']}-${data['max']}, got ${data['actual']}');
-  /// }
-  /// ```
   static const rating = RatingValidator();
 
-  // Additional validators will be added here as they are implemented
-  // static const bpm = BpmValidator();
-  // static const year = YearValidator();
-  // static const trackNumber = TrackNumberValidator();
-  // static const discNumber = DiscNumberValidator();
-  // static const iso8601Date = Iso8601DateValidator();
+  /// Validator for BPM tag values (1-999 range).
+  static const bpm = BpmValidator();
+
+  /// Validator for year tag values (1900-2100 range).
+  static const year = YearValidator();
+
+  /// Validator for track number tag values (> 0).
+  static const trackNumber = TrackNumberValidator();
+
+  /// Validator for disc number tag values (> 0).
+  static const discNumber = DiscNumberValidator();
+
+  /// Validator for date recorded tag values (ISO-8601 format).
+  static const dateRecorded = DateRecordedValidator();
 }

--- a/lib/src/validators/tag_validators.dart
+++ b/lib/src/validators/tag_validators.dart
@@ -1,0 +1,54 @@
+import 'rating_validator.dart';
+
+/// Convenience class providing access to all tag validators.
+///
+/// This class offers static constant instances of all available validators,
+/// making it easy to access validators for use in form validation, input
+/// validation, or pre-validation before creating tags.
+///
+/// Example usage:
+/// ```dart
+/// // Direct validation
+/// final error = TagValidators.rating.validate(userInput);
+/// if (error != null) {
+///   print('Invalid rating: $error');
+/// }
+///
+/// // With reactive_forms
+/// final control = FormControl<int>(
+///   validators: [
+///     Validators.delegate((c) => TagValidators.rating.validate(c.value)),
+///   ],
+/// );
+///
+/// // Pre-validation before creating tags
+/// if (TagValidators.rating.validate(value) == null) {
+///   audioFile.setTag(RatingTag(value));
+/// } else {
+///   // Show error to user
+/// }
+/// ```
+class TagValidators {
+  // Private constructor to prevent instantiation
+  TagValidators._();
+
+  /// Validator for rating tag values (0-100 range).
+  ///
+  /// Example:
+  /// ```dart
+  /// final error = TagValidators.rating.validate(150);
+  /// if (error != null) {
+  ///   // Handle validation error
+  ///   final data = error['outOfRange'];
+  ///   print('Rating must be ${data['min']}-${data['max']}, got ${data['actual']}');
+  /// }
+  /// ```
+  static const rating = RatingValidator();
+
+  // Additional validators will be added here as they are implemented
+  // static const bpm = BpmValidator();
+  // static const year = YearValidator();
+  // static const trackNumber = TrackNumberValidator();
+  // static const discNumber = DiscNumberValidator();
+  // static const iso8601Date = Iso8601DateValidator();
+}

--- a/lib/src/validators/text_validator.dart
+++ b/lib/src/validators/text_validator.dart
@@ -1,0 +1,69 @@
+import 'tag_validator.dart';
+
+/// Validator for text tag values that require non-empty content.
+///
+/// This validator ensures that text values are not empty or whitespace-only,
+/// making it useful for required metadata fields like title, artist, and album.
+///
+/// Error keys:
+/// - `empty`: Value is null, empty, or contains only whitespace
+///
+/// Example usage:
+/// ```dart
+/// const validator = TextValidator();
+///
+/// final error = validator.validate('My Song');  // null (valid)
+/// final error2 = validator.validate('');        // {empty: {...}}
+/// final error3 = validator.validate('   ');     // {empty: {...}}
+/// ```
+class TextValidator extends TagValidator<String> {
+  /// Error key for empty values.
+  static const String emptyError = 'empty';
+
+  /// The field name for error messages.
+  final String fieldName;
+
+  /// Creates a new text validator.
+  ///
+  /// The [fieldName] is used in error messages to provide context-specific
+  /// feedback (e.g., "Title cannot be empty" vs "Artist cannot be empty").
+  const TextValidator({required this.fieldName});
+
+  @override
+  Map<String, dynamic>? validate(String? value) {
+    // Null values are allowed (optional field)
+    if (value == null) return null;
+
+    // Check for empty or whitespace-only string
+    if (value.trim().isEmpty) {
+      return {
+        emptyError: {
+          'fieldName': fieldName,
+          'actual': value,
+        },
+      };
+    }
+
+    return null;
+  }
+
+  @override
+  String validateOrThrow(String value) {
+    final error = validate(value);
+    if (error != null) {
+      throw ArgumentError(formatErrorMessage(error));
+    }
+    // Return trimmed value (normalized)
+    return value.trim();
+  }
+
+  @override
+  String formatErrorMessage(Map<String, dynamic> error) {
+    if (error.containsKey(emptyError)) {
+      final details = error[emptyError] as Map<String, dynamic>;
+      final actual = details['actual'] as String;
+      return '$fieldName cannot be empty. Actual: "${actual}"';
+    }
+    return 'Invalid $fieldName value';
+  }
+}

--- a/lib/src/validators/title_validator.dart
+++ b/lib/src/validators/title_validator.dart
@@ -1,0 +1,27 @@
+import 'text_validator.dart';
+
+/// Validator for title tag values.
+///
+/// This validator ensures that title values are not empty or whitespace-only.
+///
+/// Error keys:
+/// - `empty`: Value is empty or contains only whitespace
+///
+/// Example usage:
+/// ```dart
+/// const validator = TitleValidator();
+///
+/// final error = validator.validate('My Song');  // null (valid)
+/// final error2 = validator.validate('');        // {empty: {...}}
+/// ```
+final class TitleValidator extends TextValidator {
+  /// Creates a new title validator.
+  const TitleValidator() : super(fieldName: 'Title');
+
+  /// Checks if a value is a valid title.
+  ///
+  /// Returns `true` if the value is valid, `false` otherwise.
+  static bool isValid(String? value) {
+    return const TitleValidator().validate(value) == null;
+  }
+}

--- a/lib/src/validators/track_number_validator.dart
+++ b/lib/src/validators/track_number_validator.dart
@@ -1,0 +1,60 @@
+import 'tag_validator.dart';
+
+/// Validator for track number tag values.
+///
+/// This validator ensures that track number values are positive integers
+/// greater than 0, representing the track's position within an album or collection.
+///
+/// Error keys:
+/// - `notPositive`: Value is not a positive integer (must be > 0)
+///
+/// Example usage:
+/// ```dart
+/// const validator = TrackNumberValidator();
+///
+/// final error = validator.validate(5);   // null (valid)
+/// final error2 = validator.validate(0);  // {notPositive: {...}}
+/// final error3 = validator.validate(-1); // {notPositive: {...}}
+/// ```
+final class TrackNumberValidator extends TagValidator<int> {
+  /// The minimum valid track number value (exclusive).
+  static const int min = 0;
+
+  /// Error key for non-positive values.
+  static const String notPositiveError = 'notPositive';
+
+  /// Creates a new track number validator.
+  const TrackNumberValidator();
+
+  @override
+  Map<String, dynamic>? validate(int? value) {
+    // Null values are allowed (optional field)
+    if (value == null) return null;
+
+    // Check if positive
+    if (value <= min) {
+      return {
+        notPositiveError: {
+          'actual': value,
+        },
+      };
+    }
+
+    return null;
+  }
+
+  @override
+  String formatErrorMessage(Map<String, dynamic> error) {
+    if (error.containsKey(notPositiveError)) {
+      return 'Track number must be greater than 0';
+    }
+    return 'Invalid track number';
+  }
+
+  /// Checks if a value is a valid track number.
+  ///
+  /// Returns `true` if the value is valid, `false` otherwise.
+  static bool isValid(int? value) {
+    return const TrackNumberValidator().validate(value) == null;
+  }
+}

--- a/lib/src/validators/year_validator.dart
+++ b/lib/src/validators/year_validator.dart
@@ -1,0 +1,66 @@
+import 'tag_validator.dart';
+
+/// Validator for year tag values.
+///
+/// This validator ensures that year values are within the valid range
+/// of 1900-2100 (inclusive), representing a four-digit year that accommodates
+/// historical recordings and future releases.
+///
+/// Error keys:
+/// - `outOfRange`: Value is outside the valid range (1900-2100)
+///
+/// Example usage:
+/// ```dart
+/// const validator = YearValidator();
+///
+/// final error = validator.validate(2023);  // null (valid)
+/// final error2 = validator.validate(1800); // {outOfRange: {...}}
+/// final error3 = validator.validate(2200); // {outOfRange: {...}}
+/// ```
+final class YearValidator extends TagValidator<int> {
+  /// The minimum valid year value (inclusive).
+  static const int min = 1900;
+
+  /// The maximum valid year value (inclusive).
+  static const int max = 2100;
+
+  /// Error key for out-of-range values.
+  static const String outOfRangeError = 'outOfRange';
+
+  /// Creates a new year validator.
+  const YearValidator();
+
+  @override
+  Map<String, dynamic>? validate(int? value) {
+    // Null values are allowed (optional field)
+    if (value == null) return null;
+
+    // Check range
+    if (value < min || value > max) {
+      return {
+        outOfRangeError: {
+          'min': min,
+          'max': max,
+          'actual': value,
+        },
+      };
+    }
+
+    return null;
+  }
+
+  @override
+  String formatErrorMessage(Map<String, dynamic> error) {
+    if (error.containsKey(outOfRangeError)) {
+      return 'Year must be between $min and $max (inclusive)';
+    }
+    return 'Invalid year value';
+  }
+
+  /// Checks if a value is within the valid year range.
+  ///
+  /// Returns `true` if the value is valid, `false` otherwise.
+  static bool isValid(int? value) {
+    return const YearValidator().validate(value) == null;
+  }
+}

--- a/test/tags/bpm_tag_test.dart
+++ b/test/tags/bpm_tag_test.dart
@@ -171,14 +171,14 @@ void main() {
         );
       });
 
-      test('ArgumentError includes the invalid value', () {
+      test('ArgumentError includes descriptive message', () {
         expect(
           () => BpmTag(0),
           throwsA(
             isA<ArgumentError>().having(
-              (e) => e.invalidValue,
-              'invalidValue',
-              equals(0),
+              (e) => e.message,
+              'message',
+              contains('BPM must be between 1 and 999'),
             ),
           ),
         );
@@ -187,9 +187,9 @@ void main() {
           () => BpmTag(1000),
           throwsA(
             isA<ArgumentError>().having(
-              (e) => e.invalidValue,
-              'invalidValue',
-              equals(1000),
+              (e) => e.message,
+              'message',
+              contains('BPM must be between 1 and 999'),
             ),
           ),
         );
@@ -198,22 +198,9 @@ void main() {
           () => BpmTag(-10),
           throwsA(
             isA<ArgumentError>().having(
-              (e) => e.invalidValue,
-              'invalidValue',
-              equals(-10),
-            ),
-          ),
-        );
-      });
-
-      test('ArgumentError includes parameter name', () {
-        expect(
-          () => BpmTag(0),
-          throwsA(
-            isA<ArgumentError>().having(
-              (e) => e.name,
-              'name',
-              equals('value'),
+              (e) => e.message,
+              'message',
+              contains('BPM must be between 1 and 999'),
             ),
           ),
         );
@@ -766,8 +753,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('BPM must be between 1 and 999 (inclusive)'));
-          expect(error.invalidValue, equals(0));
-          expect(error.name, equals('value'));
         }
       });
 
@@ -779,8 +764,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('BPM must be between 1 and 999 (inclusive)'));
-          expect(error.invalidValue, equals(1000));
-          expect(error.name, equals('value'));
         }
       });
 
@@ -792,8 +775,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('BPM must be between 1 and 999 (inclusive)'));
-          expect(error.invalidValue, equals(-50));
-          expect(error.name, equals('value'));
         }
       });
 

--- a/test/tags/date_recorded_tag_test.dart
+++ b/test/tags/date_recorded_tag_test.dart
@@ -397,27 +397,14 @@ void main() {
           }
         });
 
-        test('ArgumentError includes the invalid value', () {
+        test('ArgumentError includes descriptive message', () {
           expect(
             () => DateRecordedTag('invalid-date'),
             throwsA(
               isA<ArgumentError>().having(
-                (e) => e.invalidValue,
-                'invalidValue',
-                equals('invalid-date'),
-              ),
-            ),
-          );
-        });
-
-        test('ArgumentError includes parameter name', () {
-          expect(
-            () => DateRecordedTag('invalid'),
-            throwsA(
-              isA<ArgumentError>().having(
-                (e) => e.name,
-                'name',
-                equals('value'),
+                (e) => e.message,
+                'message',
+                contains('ISO-8601 format'),
               ),
             ),
           );
@@ -946,8 +933,6 @@ void main() {
           expect(error.message, contains('2023'));
           expect(error.message, contains('2023-03-15'));
           expect(error.message, contains('2023-03-15T14:30:00Z'));
-          expect(error.invalidValue, equals('invalid-date'));
-          expect(error.name, equals('value'));
         }
       });
 
@@ -959,8 +944,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('Year must be between 1900 and 2100 (inclusive)'));
-          expect(error.invalidValue, equals('1800-01-01'));
-          expect(error.name, equals('value'));
         }
       });
 
@@ -972,8 +955,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('Month must be between 01 and 12'));
-          expect(error.invalidValue, equals('2023-13-15'));
-          expect(error.name, equals('value'));
         }
       });
 
@@ -985,8 +966,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('Day 30 is not valid for year 2023 month 2'));
-          expect(error.invalidValue, equals('2023-02-30'));
-          expect(error.name, equals('value'));
         }
       });
 

--- a/test/tags/disc_number_tag_test.dart
+++ b/test/tags/disc_number_tag_test.dart
@@ -114,14 +114,14 @@ void main() {
         );
       });
 
-      test('ArgumentError includes the invalid value', () {
+      test('ArgumentError includes descriptive message', () {
         expect(
           () => DiscNumberTag(0),
           throwsA(
             isA<ArgumentError>().having(
-              (e) => e.invalidValue,
-              'invalidValue',
-              equals(0),
+              (e) => e.message,
+              'message',
+              contains('Disc number must be greater than 0'),
             ),
           ),
         );
@@ -130,22 +130,9 @@ void main() {
           () => DiscNumberTag(-10),
           throwsA(
             isA<ArgumentError>().having(
-              (e) => e.invalidValue,
-              'invalidValue',
-              equals(-10),
-            ),
-          ),
-        );
-      });
-
-      test('ArgumentError includes parameter name', () {
-        expect(
-          () => DiscNumberTag(0),
-          throwsA(
-            isA<ArgumentError>().having(
-              (e) => e.name,
-              'name',
-              equals('value'),
+              (e) => e.message,
+              'message',
+              contains('Disc number must be greater than 0'),
             ),
           ),
         );
@@ -612,8 +599,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('Disc number must be greater than 0'));
-          expect(error.invalidValue, equals(0));
-          expect(error.name, equals('value'));
         }
       });
 
@@ -625,8 +610,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('Disc number must be greater than 0'));
-          expect(error.invalidValue, equals(-3));
-          expect(error.name, equals('value'));
         }
       });
 

--- a/test/tags/rating_tag_test.dart
+++ b/test/tags/rating_tag_test.dart
@@ -184,14 +184,14 @@ void main() {
         );
       });
 
-      test('ArgumentError includes the invalid value', () {
+      test('ArgumentError includes descriptive message', () {
         expect(
           () => RatingTag(-1),
           throwsA(
             isA<ArgumentError>().having(
-              (e) => e.invalidValue,
-              'invalidValue',
-              equals(-1),
+              (e) => e.message,
+              'message',
+              contains('Rating must be between 0 and 100'),
             ),
           ),
         );
@@ -200,9 +200,9 @@ void main() {
           () => RatingTag(101),
           throwsA(
             isA<ArgumentError>().having(
-              (e) => e.invalidValue,
-              'invalidValue',
-              equals(101),
+              (e) => e.message,
+              'message',
+              contains('Rating must be between 0 and 100'),
             ),
           ),
         );
@@ -211,22 +211,9 @@ void main() {
           () => RatingTag(-10),
           throwsA(
             isA<ArgumentError>().having(
-              (e) => e.invalidValue,
-              'invalidValue',
-              equals(-10),
-            ),
-          ),
-        );
-      });
-
-      test('ArgumentError includes parameter name', () {
-        expect(
-          () => RatingTag(-1),
-          throwsA(
-            isA<ArgumentError>().having(
-              (e) => e.name,
-              'name',
-              equals('value'),
+              (e) => e.message,
+              'message',
+              contains('Rating must be between 0 and 100'),
             ),
           ),
         );
@@ -761,8 +748,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('Rating must be between 0 and 100 (inclusive)'));
-          expect(error.invalidValue, equals(-1));
-          expect(error.name, equals('value'));
         }
       });
 
@@ -774,8 +759,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('Rating must be between 0 and 100 (inclusive)'));
-          expect(error.invalidValue, equals(101));
-          expect(error.name, equals('value'));
         }
       });
 
@@ -787,8 +770,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('Rating must be between 0 and 100 (inclusive)'));
-          expect(error.invalidValue, equals(-50));
-          expect(error.name, equals('value'));
         }
       });
 

--- a/test/tags/track_number_tag_test.dart
+++ b/test/tags/track_number_tag_test.dart
@@ -114,14 +114,14 @@ void main() {
         );
       });
 
-      test('ArgumentError includes the invalid value', () {
+      test('ArgumentError includes descriptive message', () {
         expect(
           () => TrackNumberTag(0),
           throwsA(
             isA<ArgumentError>().having(
-              (e) => e.invalidValue,
-              'invalidValue',
-              equals(0),
+              (e) => e.message,
+              'message',
+              contains('Track number must be greater than 0'),
             ),
           ),
         );
@@ -130,22 +130,9 @@ void main() {
           () => TrackNumberTag(-10),
           throwsA(
             isA<ArgumentError>().having(
-              (e) => e.invalidValue,
-              'invalidValue',
-              equals(-10),
-            ),
-          ),
-        );
-      });
-
-      test('ArgumentError includes parameter name', () {
-        expect(
-          () => TrackNumberTag(0),
-          throwsA(
-            isA<ArgumentError>().having(
-              (e) => e.name,
-              'name',
-              equals('value'),
+              (e) => e.message,
+              'message',
+              contains('Track number must be greater than 0'),
             ),
           ),
         );
@@ -600,8 +587,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('Track number must be greater than 0'));
-          expect(error.invalidValue, equals(0));
-          expect(error.name, equals('value'));
         }
       });
 
@@ -613,8 +598,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('Track number must be greater than 0'));
-          expect(error.invalidValue, equals(-5));
-          expect(error.name, equals('value'));
         }
       });
 

--- a/test/tags/year_tag_test.dart
+++ b/test/tags/year_tag_test.dart
@@ -187,14 +187,14 @@ void main() {
         );
       });
 
-      test('ArgumentError includes the invalid value', () {
+      test('ArgumentError includes descriptive message', () {
         expect(
           () => YearTag(1899),
           throwsA(
             isA<ArgumentError>().having(
-              (e) => e.invalidValue,
-              'invalidValue',
-              equals(1899),
+              (e) => e.message,
+              'message',
+              contains('Year must be between 1900 and 2100'),
             ),
           ),
         );
@@ -203,22 +203,9 @@ void main() {
           () => YearTag(2101),
           throwsA(
             isA<ArgumentError>().having(
-              (e) => e.invalidValue,
-              'invalidValue',
-              equals(2101),
-            ),
-          ),
-        );
-      });
-
-      test('ArgumentError includes parameter name', () {
-        expect(
-          () => YearTag(1800),
-          throwsA(
-            isA<ArgumentError>().having(
-              (e) => e.name,
-              'name',
-              equals('value'),
+              (e) => e.message,
+              'message',
+              contains('Year must be between 1900 and 2100'),
             ),
           ),
         );
@@ -718,8 +705,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('Year must be between 1900 and 2100 (inclusive)'));
-          expect(error.invalidValue, equals(1899));
-          expect(error.name, equals('value'));
         }
       });
 
@@ -731,8 +716,6 @@ void main() {
           expect(e, isA<ArgumentError>());
           final error = e as ArgumentError;
           expect(error.message, contains('Year must be between 1900 and 2100 (inclusive)'));
-          expect(error.invalidValue, equals(2101));
-          expect(error.name, equals('value'));
         }
       });
 

--- a/test/validators/date_recorded_validator_test.dart
+++ b/test/validators/date_recorded_validator_test.dart
@@ -1,0 +1,517 @@
+import 'package:phonic/src/validators/date_recorded_validator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DateRecordedValidator', () {
+    const validator = DateRecordedValidator();
+
+    group('validate', () {
+      group('valid dates', () {
+        test('accepts null values', () {
+          expect(validator.validate(null), isNull);
+        });
+
+        test('accepts year-only format', () {
+          expect(validator.validate('2023'), isNull);
+          expect(validator.validate('1900'), isNull);
+          expect(validator.validate('2100'), isNull);
+          expect(validator.validate('1999'), isNull);
+        });
+
+        test('accepts year-month format', () {
+          expect(validator.validate('2023-01'), isNull);
+          expect(validator.validate('2023-12'), isNull);
+          expect(validator.validate('2000-06'), isNull);
+        });
+
+        test('accepts full date format', () {
+          expect(validator.validate('2023-03-15'), isNull);
+          expect(validator.validate('2000-01-01'), isNull);
+          expect(validator.validate('2023-12-31'), isNull);
+        });
+
+        test('accepts date with time', () {
+          expect(validator.validate('2023-03-15T14:30:00'), isNull);
+          expect(validator.validate('2023-01-01T00:00:00'), isNull);
+          expect(validator.validate('2023-12-31T23:59:59'), isNull);
+        });
+
+        test('accepts date with UTC timezone', () {
+          expect(validator.validate('2023-03-15T14:30:00Z'), isNull);
+          expect(validator.validate('2023-01-01T00:00:00Z'), isNull);
+        });
+
+        test('accepts date with timezone offset', () {
+          expect(validator.validate('2023-03-15T14:30:00+02:00'), isNull);
+          expect(validator.validate('2023-03-15T14:30:00-05:00'), isNull);
+          expect(validator.validate('2023-03-15T14:30:00+00:00'), isNull);
+        });
+
+        test('accepts date with milliseconds', () {
+          expect(validator.validate('2023-03-15T14:30:00.123'), isNull);
+          expect(validator.validate('2023-03-15T14:30:00.1Z'), isNull);
+        });
+
+        test('accepts leap year dates', () {
+          expect(validator.validate('2024-02-29'), isNull); // Leap year
+          expect(validator.validate('2000-02-29'), isNull); // Leap year
+        });
+
+        test('trims whitespace from valid dates', () {
+          expect(validator.validate('  2023  '), isNull);
+          expect(validator.validate(' 2023-03-15 '), isNull);
+          expect(validator.validate('\t2023-03-15T14:30:00Z\n'), isNull);
+        });
+      });
+
+      group('empty values', () {
+        test('rejects empty string', () {
+          final error = validator.validate('');
+          expect(error, isNotNull);
+          expect(error!.containsKey('empty'), isTrue);
+        });
+
+        test('rejects whitespace-only string', () {
+          final error = validator.validate('   ');
+          expect(error, isNotNull);
+          expect(error!.containsKey('empty'), isTrue);
+        });
+
+        test('rejects tabs and newlines', () {
+          final error = validator.validate('\t\n  ');
+          expect(error, isNotNull);
+          expect(error!.containsKey('empty'), isTrue);
+        });
+      });
+
+      group('invalid format', () {
+        test('rejects non-ISO-8601 formats', () {
+          final testCases = [
+            'March 2023',
+            '03/15/2023',
+            '15-03-2023',
+            '2023/03/15',
+            'not a date',
+            '23',
+            '202',
+          ];
+
+          for (final testCase in testCases) {
+            final error = validator.validate(testCase);
+            expect(error, isNotNull, reason: 'Expected error for: $testCase');
+            expect(error!.containsKey('invalidFormat'), isTrue, reason: 'Expected invalidFormat error for: $testCase');
+          }
+        });
+
+        test('rejects partial timestamps', () {
+          expect(validator.validate('2023-03-15T14'), isNotNull);
+          expect(validator.validate('2023-03-15T14:30'), isNotNull);
+        });
+      });
+
+      group('year validation', () {
+        test('rejects years before 1900', () {
+          final error = validator.validate('1899');
+          expect(error, isNotNull);
+          expect(error!.containsKey('yearOutOfRange'), isTrue);
+
+          final details = error['yearOutOfRange'] as Map<String, dynamic>;
+          expect(details['min'], equals(1900));
+          expect(details['max'], equals(2100));
+          expect(details['actual'], equals(1899));
+        });
+
+        test('rejects years after 2100', () {
+          final error = validator.validate('2101');
+          expect(error, isNotNull);
+          expect(error!.containsKey('yearOutOfRange'), isTrue);
+
+          final details = error['yearOutOfRange'] as Map<String, dynamic>;
+          expect(details['actual'], equals(2101));
+        });
+
+        test('rejects year out of range in full dates', () {
+          expect(validator.validate('1800-03-15'), isNotNull);
+          expect(validator.validate('2200-03-15'), isNotNull);
+        });
+      });
+
+      group('month validation', () {
+        test('rejects month 00', () {
+          final error = validator.validate('2023-00');
+          expect(error, isNotNull);
+          expect(error!.containsKey('invalidMonth'), isTrue);
+
+          final details = error['invalidMonth'] as Map<String, dynamic>;
+          expect(details['actual'], equals(0));
+          expect(details['min'], equals(1));
+          expect(details['max'], equals(12));
+        });
+
+        test('rejects month 13', () {
+          final error = validator.validate('2023-13');
+          expect(error, isNotNull);
+          expect(error!.containsKey('invalidMonth'), isTrue);
+
+          final details = error['invalidMonth'] as Map<String, dynamic>;
+          expect(details['actual'], equals(13));
+        });
+
+        test('rejects invalid months in full dates', () {
+          expect(validator.validate('2023-00-15'), isNotNull);
+          expect(validator.validate('2023-13-15'), isNotNull);
+        });
+      });
+
+      group('day validation', () {
+        test('rejects day 00', () {
+          final error = validator.validate('2023-03-00');
+          expect(error, isNotNull);
+          expect(error!.containsKey('invalidDay'), isTrue);
+        });
+
+        test('rejects day 32 for 31-day months', () {
+          final error = validator.validate('2023-01-32');
+          expect(error, isNotNull);
+          expect(error!.containsKey('invalidDay'), isTrue);
+        });
+
+        test('rejects day 31 for 30-day months', () {
+          final error = validator.validate('2023-04-31');
+          expect(error, isNotNull);
+          expect(error!.containsKey('invalidDay'), isTrue);
+
+          final details = error['invalidDay'] as Map<String, dynamic>;
+          expect(details['actual'], equals(31));
+          expect(details['max'], equals(30));
+          expect(details['year'], equals(2023));
+          expect(details['month'], equals(4));
+        });
+
+        test('rejects February 30', () {
+          final error = validator.validate('2023-02-30');
+          expect(error, isNotNull);
+          expect(error!.containsKey('invalidDay'), isTrue);
+        });
+
+        test('rejects February 29 in non-leap years', () {
+          final error = validator.validate('2023-02-29'); // 2023 is not a leap year
+          expect(error, isNotNull);
+          expect(error!.containsKey('invalidDay'), isTrue);
+
+          final details = error['invalidDay'] as Map<String, dynamic>;
+          expect(details['max'], equals(28));
+        });
+
+        test('validates days for all 31-day months', () {
+          final months31 = [1, 3, 5, 7, 8, 10, 12];
+          for (final month in months31) {
+            final monthStr = month.toString().padLeft(2, '0');
+            expect(validator.validate('2023-$monthStr-31'), isNull, reason: 'Month $month should allow day 31');
+          }
+        });
+
+        test('validates days for all 30-day months', () {
+          final months30 = [4, 6, 9, 11];
+          for (final month in months30) {
+            final monthStr = month.toString().padLeft(2, '0');
+            expect(validator.validate('2023-$monthStr-30'), isNull, reason: 'Month $month should allow day 30');
+            expect(validator.validate('2023-$monthStr-31'), isNotNull, reason: 'Month $month should reject day 31');
+          }
+        });
+      });
+
+      group('time component validation', () {
+        test('rejects hour 24', () {
+          final error = validator.validate('2023-03-15T24:00:00');
+          expect(error, isNotNull);
+          expect(error!.containsKey('invalidHour'), isTrue);
+
+          final details = error['invalidHour'] as Map<String, dynamic>;
+          expect(details['actual'], equals(24));
+          expect(details['min'], equals(0));
+          expect(details['max'], equals(23));
+        });
+
+        test('rejects hour 25', () {
+          final error = validator.validate('2023-03-15T25:00:00');
+          expect(error, isNotNull);
+          expect(error!.containsKey('invalidHour'), isTrue);
+        });
+
+        test('rejects minute 60', () {
+          final error = validator.validate('2023-03-15T14:60:00');
+          expect(error, isNotNull);
+          expect(error!.containsKey('invalidMinute'), isTrue);
+
+          final details = error['invalidMinute'] as Map<String, dynamic>;
+          expect(details['actual'], equals(60));
+          expect(details['min'], equals(0));
+          expect(details['max'], equals(59));
+        });
+
+        test('rejects second 60', () {
+          final error = validator.validate('2023-03-15T14:30:60');
+          expect(error, isNotNull);
+          expect(error!.containsKey('invalidSecond'), isTrue);
+
+          final details = error['invalidSecond'] as Map<String, dynamic>;
+          expect(details['actual'], equals(60));
+          expect(details['min'], equals(0));
+          expect(details['max'], equals(59));
+        });
+
+        test('accepts time 00:00:00', () {
+          expect(validator.validate('2023-03-15T00:00:00'), isNull);
+        });
+
+        test('accepts time 23:59:59', () {
+          expect(validator.validate('2023-03-15T23:59:59'), isNull);
+        });
+      });
+    });
+
+    group('validateOrThrow', () {
+      test('returns trimmed value for valid dates', () {
+        expect(validator.validateOrThrow('  2023  '), equals('2023'));
+        expect(validator.validateOrThrow(' 2023-03-15 '), equals('2023-03-15'));
+      });
+
+      test('throws ArgumentError for empty string', () {
+        expect(
+          () => validator.validateOrThrow(''),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('throws ArgumentError for invalid format', () {
+        expect(
+          () => validator.validateOrThrow('March 2023'),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('throws ArgumentError for year out of range', () {
+        expect(
+          () => validator.validateOrThrow('1899'),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('throws ArgumentError for invalid month', () {
+        expect(
+          () => validator.validateOrThrow('2023-13'),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('throws ArgumentError for invalid day', () {
+        expect(
+          () => validator.validateOrThrow('2023-02-30'),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
+    group('formatErrorMessage', () {
+      test('formats empty error', () {
+        final error = {
+          'empty': {'actual': ''},
+        };
+        expect(
+          validator.formatErrorMessage(error),
+          equals('Date recorded cannot be empty'),
+        );
+      });
+
+      test('formats invalidFormat error', () {
+        final error = {
+          'invalidFormat': {
+            'actual': 'March 2023',
+            'expected': 'ISO-8601 format',
+          },
+        };
+        expect(
+          validator.formatErrorMessage(error),
+          contains('ISO-8601 format'),
+        );
+      });
+
+      test('formats yearOutOfRange error', () {
+        final error = {
+          'yearOutOfRange': {
+            'min': 1900,
+            'max': 2100,
+            'actual': 1899,
+          },
+        };
+        expect(
+          validator.formatErrorMessage(error),
+          equals('Year must be between 1900 and 2100 (inclusive)'),
+        );
+      });
+
+      test('formats invalidMonth error', () {
+        final error = {
+          'invalidMonth': {
+            'actual': 13,
+            'min': 1,
+            'max': 12,
+          },
+        };
+        expect(
+          validator.formatErrorMessage(error),
+          equals('Month must be between 01 and 12'),
+        );
+      });
+
+      test('formats invalidDay error', () {
+        final error = {
+          'invalidDay': {
+            'actual': 31,
+            'max': 30,
+            'year': 2023,
+            'month': 4,
+          },
+        };
+        expect(
+          validator.formatErrorMessage(error),
+          equals('Day 31 is not valid for year 2023 month 4'),
+        );
+      });
+
+      test('formats invalidHour error', () {
+        final error = {
+          'invalidHour': {
+            'actual': 24,
+            'min': 0,
+            'max': 23,
+          },
+        };
+        expect(
+          validator.formatErrorMessage(error),
+          equals('Hour must be between 00 and 23'),
+        );
+      });
+
+      test('formats invalidMinute error', () {
+        final error = {
+          'invalidMinute': {
+            'actual': 60,
+            'min': 0,
+            'max': 59,
+          },
+        };
+        expect(
+          validator.formatErrorMessage(error),
+          equals('Minute must be between 00 and 59'),
+        );
+      });
+
+      test('formats invalidSecond error', () {
+        final error = {
+          'invalidSecond': {
+            'actual': 60,
+            'min': 0,
+            'max': 59,
+          },
+        };
+        expect(
+          validator.formatErrorMessage(error),
+          equals('Second must be between 00 and 59'),
+        );
+      });
+
+      test('returns generic message for unknown error', () {
+        final error = {'unknown': {}};
+        expect(
+          validator.formatErrorMessage(error),
+          equals('Invalid date recorded value'),
+        );
+      });
+    });
+
+    group('isValid static method', () {
+      test('returns true for valid dates', () {
+        expect(DateRecordedValidator.isValid('2023'), isTrue);
+        expect(DateRecordedValidator.isValid('2023-03-15'), isTrue);
+        expect(DateRecordedValidator.isValid('2023-03-15T14:30:00Z'), isTrue);
+        expect(DateRecordedValidator.isValid(null), isTrue);
+      });
+
+      test('returns false for invalid dates', () {
+        expect(DateRecordedValidator.isValid(''), isFalse);
+        expect(DateRecordedValidator.isValid('March 2023'), isFalse);
+        expect(DateRecordedValidator.isValid('1899'), isFalse);
+        expect(DateRecordedValidator.isValid('2023-13-01'), isFalse);
+        expect(DateRecordedValidator.isValid('2023-02-30'), isFalse);
+      });
+    });
+
+    group('leap year handling', () {
+      test('correctly identifies leap years divisible by 4', () {
+        expect(validator.validate('2024-02-29'), isNull); // Divisible by 4
+        expect(validator.validate('2020-02-29'), isNull); // Divisible by 4
+      });
+
+      test('correctly handles century years not divisible by 400', () {
+        expect(validator.validate('1900-02-29'), isNotNull); // Not a leap year
+        expect(validator.validate('2100-02-29'), isNotNull); // Not a leap year (if year range extended)
+      });
+
+      test('correctly handles century years divisible by 400', () {
+        expect(validator.validate('2000-02-29'), isNull); // Leap year
+      });
+
+      test('rejects Feb 29 in non-leap years', () {
+        expect(validator.validate('2023-02-29'), isNotNull);
+        expect(validator.validate('2021-02-29'), isNotNull);
+        expect(validator.validate('2022-02-29'), isNotNull);
+      });
+
+      test('accepts Feb 28 in all years', () {
+        expect(validator.validate('2023-02-28'), isNull);
+        expect(validator.validate('2024-02-28'), isNull);
+        expect(validator.validate('1900-02-28'), isNull);
+        expect(validator.validate('2000-02-28'), isNull);
+      });
+    });
+
+    group('edge cases', () {
+      test('handles minimum valid date', () {
+        expect(validator.validate('1900-01-01'), isNull);
+        expect(validator.validate('1900-01-01T00:00:00Z'), isNull);
+      });
+
+      test('handles maximum valid date', () {
+        expect(validator.validate('2100-12-31'), isNull);
+        expect(validator.validate('2100-12-31T23:59:59Z'), isNull);
+      });
+
+      test('handles boundary years', () {
+        expect(validator.validate('1900'), isNull);
+        expect(validator.validate('2100'), isNull);
+        expect(validator.validate('1899'), isNotNull);
+        expect(validator.validate('2101'), isNotNull);
+      });
+
+      test('handles all month boundaries', () {
+        // January (31 days)
+        expect(validator.validate('2023-01-31'), isNull);
+        expect(validator.validate('2023-01-32'), isNotNull);
+
+        // April (30 days)
+        expect(validator.validate('2023-04-30'), isNull);
+        expect(validator.validate('2023-04-31'), isNotNull);
+
+        // February in leap year
+        expect(validator.validate('2024-02-29'), isNull);
+        expect(validator.validate('2024-02-30'), isNotNull);
+
+        // February in non-leap year
+        expect(validator.validate('2023-02-28'), isNull);
+        expect(validator.validate('2023-02-29'), isNotNull);
+      });
+    });
+  });
+}

--- a/test/validators/rating_validator_test.dart
+++ b/test/validators/rating_validator_test.dart
@@ -1,0 +1,191 @@
+import 'package:phonic/phonic.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RatingValidator', () {
+    const validator = RatingValidator();
+
+    group('validate', () {
+      test('returns null for valid ratings within range', () {
+        expect(validator.validate(0), isNull);
+        expect(validator.validate(50), isNull);
+        expect(validator.validate(100), isNull);
+        expect(validator.validate(1), isNull);
+        expect(validator.validate(99), isNull);
+      });
+
+      test('returns null for null values', () {
+        expect(validator.validate(null), isNull);
+      });
+
+      test('returns error map for ratings below minimum', () {
+        final error = validator.validate(-1);
+        expect(error, isNotNull);
+        expect(error!['outOfRange'], isNotNull);
+        final rangeError = error['outOfRange'] as Map<String, dynamic>;
+        expect(rangeError['min'], equals(0));
+        expect(rangeError['max'], equals(100));
+        expect(rangeError['actual'], equals(-1));
+      });
+
+      test('returns error map for ratings above maximum', () {
+        final error = validator.validate(101);
+        expect(error, isNotNull);
+        expect(error!['outOfRange'], isNotNull);
+        final rangeError = error['outOfRange'] as Map<String, dynamic>;
+        expect(rangeError['min'], equals(0));
+        expect(rangeError['max'], equals(100));
+        expect(rangeError['actual'], equals(101));
+      });
+
+      test('returns error map for extremely low values', () {
+        final error = validator.validate(-1000);
+        expect(error, isNotNull);
+        final rangeError = error!['outOfRange'] as Map<String, dynamic>;
+        expect(rangeError['actual'], equals(-1000));
+      });
+
+      test('returns error map for extremely high values', () {
+        final error = validator.validate(1000);
+        expect(error, isNotNull);
+        final rangeError = error!['outOfRange'] as Map<String, dynamic>;
+        expect(rangeError['actual'], equals(1000));
+      });
+    });
+
+    group('validateOrThrow', () {
+      test('returns value for valid ratings', () {
+        expect(validator.validateOrThrow(0), equals(0));
+        expect(validator.validateOrThrow(50), equals(50));
+        expect(validator.validateOrThrow(100), equals(100));
+      });
+
+      test('throws ArgumentError for invalid ratings', () {
+        expect(
+          () => validator.validateOrThrow(-1),
+          throwsA(isA<ArgumentError>()),
+        );
+        expect(
+          () => validator.validateOrThrow(101),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('ArgumentError contains proper error message', () {
+        try {
+          validator.validateOrThrow(150);
+          fail('Should have thrown ArgumentError');
+        } on ArgumentError catch (e) {
+          expect(e.message, contains('Rating must be between 0 and 100'));
+        }
+      });
+    });
+
+    group('formatErrorMessage', () {
+      test('formats error message correctly', () {
+        final error = {
+          'outOfRange': {
+            'min': 0,
+            'max': 100,
+            'actual': 150,
+          },
+        };
+        final message = validator.formatErrorMessage(error);
+        expect(message, equals('Rating must be between 0 and 100 (inclusive)'));
+      });
+    });
+
+    group('isValid static method', () {
+      test('returns true for valid ratings', () {
+        expect(RatingValidator.isValid(0), isTrue);
+        expect(RatingValidator.isValid(50), isTrue);
+        expect(RatingValidator.isValid(100), isTrue);
+      });
+
+      test('returns true for null values', () {
+        expect(RatingValidator.isValid(null), isTrue);
+      });
+
+      test('returns false for invalid ratings', () {
+        expect(RatingValidator.isValid(-1), isFalse);
+        expect(RatingValidator.isValid(101), isFalse);
+        expect(RatingValidator.isValid(1000), isFalse);
+      });
+    });
+
+    group('constants', () {
+      test('min constant is correct', () {
+        expect(RatingValidator.min, equals(0));
+      });
+
+      test('max constant is correct', () {
+        expect(RatingValidator.max, equals(100));
+      });
+
+      test('outOfRangeError constant is correct', () {
+        expect(RatingValidator.outOfRangeError, equals('outOfRange'));
+      });
+    });
+
+    group('integration with RatingTag', () {
+      test('RatingTag uses validator correctly', () {
+        expect(() => RatingTag(50), returnsNormally);
+        expect(() => RatingTag(0), returnsNormally);
+        expect(() => RatingTag(100), returnsNormally);
+      });
+
+      test('RatingTag throws same error as validator', () {
+        expect(() => RatingTag(101), throwsA(isA<ArgumentError>()));
+        expect(() => RatingTag(-1), throwsA(isA<ArgumentError>()));
+      });
+
+      test('RatingTag.validator is accessible', () {
+        expect(RatingTag.validator, isA<RatingValidator>());
+        expect(RatingTag.validator.validate(50), isNull);
+        expect(RatingTag.validator.validate(150), isNotNull);
+      });
+    });
+
+    group('TagValidators convenience class', () {
+      test('provides access to rating validator', () {
+        expect(TagValidators.rating, isA<RatingValidator>());
+        expect(TagValidators.rating.validate(50), isNull);
+        expect(TagValidators.rating.validate(150), isNotNull);
+      });
+    });
+
+    group('boundary conditions', () {
+      test('validates exact boundary values', () {
+        expect(validator.validate(0), isNull);
+        expect(validator.validate(100), isNull);
+      });
+
+      test('invalidates values just outside boundaries', () {
+        expect(validator.validate(-1), isNotNull);
+        expect(validator.validate(101), isNotNull);
+      });
+    });
+
+    group('error structure', () {
+      test('error contains all required fields', () {
+        final error = validator.validate(150);
+        expect(error, isNotNull);
+        expect(error!.containsKey('outOfRange'), isTrue);
+
+        final rangeError = error['outOfRange'] as Map<String, dynamic>;
+        expect(rangeError.containsKey('min'), isTrue);
+        expect(rangeError.containsKey('max'), isTrue);
+        expect(rangeError.containsKey('actual'), isTrue);
+      });
+
+      test('error values are correct types', () {
+        final error = validator.validate(150);
+        final rangeError = error!['outOfRange'] as Map<String, dynamic>;
+
+        expect(rangeError['min'], isA<int>());
+        expect(rangeError['max'], isA<int>());
+        expect(rangeError['actual'], isA<int>());
+      });
+    });
+  });
+}

--- a/test/validators/text_validator_test.dart
+++ b/test/validators/text_validator_test.dart
@@ -1,0 +1,345 @@
+import 'package:phonic/phonic.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TitleValidator', () {
+    late TitleValidator validator;
+
+    setUp(() {
+      validator = const TitleValidator();
+    });
+
+    group('validate()', () {
+      test('returns null for valid non-empty title', () {
+        expect(validator.validate('My Song'), isNull);
+      });
+
+      test('returns null for title with leading/trailing whitespace', () {
+        expect(validator.validate('  My Song  '), isNull);
+      });
+
+      test('returns null for title with special characters', () {
+        expect(validator.validate('Song #1 (Live)'), isNull);
+      });
+
+      test('returns null for title with unicode characters', () {
+        expect(validator.validate('Café Müller'), isNull);
+      });
+
+      test('returns null for single character title', () {
+        expect(validator.validate('A'), isNull);
+      });
+
+      test('returns error map for empty title', () {
+        final result = validator.validate('');
+        expect(result, isNotNull);
+        expect(result!.keys.single, equals('empty'));
+        expect(result['empty']!['fieldName'], equals('Title'));
+        expect(result['empty']!['actual'], equals(''));
+      });
+
+      test('returns error map for whitespace-only title', () {
+        final result = validator.validate('   ');
+        expect(result, isNotNull);
+        expect(result!.keys.single, equals('empty'));
+        expect(result['empty']!['fieldName'], equals('Title'));
+        expect(result['empty']!['actual'], equals('   '));
+      });
+
+      test('returns error map for tab-only title', () {
+        final result = validator.validate('\t\t');
+        expect(result, isNotNull);
+        expect(result!.keys.single, equals('empty'));
+      });
+
+      test('returns error map for newline-only title', () {
+        final result = validator.validate('\n');
+        expect(result, isNotNull);
+        expect(result!.keys.single, equals('empty'));
+      });
+    });
+
+    group('validateOrThrow()', () {
+      test('returns trimmed value for valid title', () {
+        expect(validator.validateOrThrow('My Song'), equals('My Song'));
+      });
+
+      test('trims leading whitespace', () {
+        expect(validator.validateOrThrow('  My Song'), equals('My Song'));
+      });
+
+      test('trims trailing whitespace', () {
+        expect(validator.validateOrThrow('My Song  '), equals('My Song'));
+      });
+
+      test('trims both leading and trailing whitespace', () {
+        expect(validator.validateOrThrow('  My Song  '), equals('My Song'));
+      });
+
+      test('throws ArgumentError for empty title', () {
+        expect(
+          () => validator.validateOrThrow(''),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Title cannot be empty'),
+            ),
+          ),
+        );
+      });
+
+      test('throws ArgumentError for whitespace-only title', () {
+        expect(
+          () => validator.validateOrThrow('   '),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Title cannot be empty'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('formatErrorMessage()', () {
+      test('formats empty error message correctly', () {
+        final error = validator.validate('');
+        final message = validator.formatErrorMessage(error!);
+        expect(message, equals('Title cannot be empty. Actual: ""'));
+      });
+
+      test('formats whitespace error message correctly', () {
+        final error = validator.validate('   ');
+        final message = validator.formatErrorMessage(error!);
+        expect(message, equals('Title cannot be empty. Actual: "   "'));
+      });
+    });
+
+    group('isValid()', () {
+      test('returns true for valid title', () {
+        expect(TitleValidator.isValid('My Song'), isTrue);
+      });
+
+      test('returns true for title with whitespace', () {
+        expect(TitleValidator.isValid('  My Song  '), isTrue);
+      });
+
+      test('returns false for empty title', () {
+        expect(TitleValidator.isValid(''), isFalse);
+      });
+
+      test('returns false for whitespace-only title', () {
+        expect(TitleValidator.isValid('   '), isFalse);
+      });
+    });
+  });
+
+  group('ArtistValidator', () {
+    late ArtistValidator validator;
+
+    setUp(() {
+      validator = const ArtistValidator();
+    });
+
+    group('validate()', () {
+      test('returns null for valid non-empty artist', () {
+        expect(validator.validate('The Beatles'), isNull);
+      });
+
+      test('returns null for artist with leading/trailing whitespace', () {
+        expect(validator.validate('  The Beatles  '), isNull);
+      });
+
+      test('returns null for artist with special characters', () {
+        expect(validator.validate('AC/DC'), isNull);
+      });
+
+      test('returns null for single character artist', () {
+        expect(validator.validate('A'), isNull);
+      });
+
+      test('returns error map for empty artist', () {
+        final result = validator.validate('');
+        expect(result, isNotNull);
+        expect(result!.keys.single, equals('empty'));
+        expect(result['empty']!['fieldName'], equals('Artist'));
+        expect(result['empty']!['actual'], equals(''));
+      });
+
+      test('returns error map for whitespace-only artist', () {
+        final result = validator.validate('   ');
+        expect(result, isNotNull);
+        expect(result!.keys.single, equals('empty'));
+        expect(result['empty']!['fieldName'], equals('Artist'));
+      });
+    });
+
+    group('validateOrThrow()', () {
+      test('returns trimmed value for valid artist', () {
+        expect(validator.validateOrThrow('The Beatles'), equals('The Beatles'));
+      });
+
+      test('trims whitespace', () {
+        expect(
+          validator.validateOrThrow('  The Beatles  '),
+          equals('The Beatles'),
+        );
+      });
+
+      test('throws ArgumentError for empty artist', () {
+        expect(
+          () => validator.validateOrThrow(''),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Artist cannot be empty'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('formatErrorMessage()', () {
+      test('formats empty error message correctly', () {
+        final error = validator.validate('');
+        final message = validator.formatErrorMessage(error!);
+        expect(message, equals('Artist cannot be empty. Actual: ""'));
+      });
+    });
+
+    group('isValid()', () {
+      test('returns true for valid artist', () {
+        expect(ArtistValidator.isValid('The Beatles'), isTrue);
+      });
+
+      test('returns false for empty artist', () {
+        expect(ArtistValidator.isValid(''), isFalse);
+      });
+    });
+  });
+
+  group('AlbumValidator', () {
+    late AlbumValidator validator;
+
+    setUp(() {
+      validator = const AlbumValidator();
+    });
+
+    group('validate()', () {
+      test('returns null for valid non-empty album', () {
+        expect(validator.validate('Abbey Road'), isNull);
+      });
+
+      test('returns null for album with leading/trailing whitespace', () {
+        expect(validator.validate('  Abbey Road  '), isNull);
+      });
+
+      test('returns null for album with special characters', () {
+        expect(validator.validate('Album #1 (Deluxe Edition)'), isNull);
+      });
+
+      test('returns null for single character album', () {
+        expect(validator.validate('A'), isNull);
+      });
+
+      test('returns error map for empty album', () {
+        final result = validator.validate('');
+        expect(result, isNotNull);
+        expect(result!.keys.single, equals('empty'));
+        expect(result['empty']!['fieldName'], equals('Album'));
+        expect(result['empty']!['actual'], equals(''));
+      });
+
+      test('returns error map for whitespace-only album', () {
+        final result = validator.validate('   ');
+        expect(result, isNotNull);
+        expect(result!.keys.single, equals('empty'));
+        expect(result['empty']!['fieldName'], equals('Album'));
+      });
+    });
+
+    group('validateOrThrow()', () {
+      test('returns trimmed value for valid album', () {
+        expect(validator.validateOrThrow('Abbey Road'), equals('Abbey Road'));
+      });
+
+      test('trims whitespace', () {
+        expect(
+          validator.validateOrThrow('  Abbey Road  '),
+          equals('Abbey Road'),
+        );
+      });
+
+      test('throws ArgumentError for empty album', () {
+        expect(
+          () => validator.validateOrThrow(''),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Album cannot be empty'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('formatErrorMessage()', () {
+      test('formats empty error message correctly', () {
+        final error = validator.validate('');
+        final message = validator.formatErrorMessage(error!);
+        expect(message, equals('Album cannot be empty. Actual: ""'));
+      });
+    });
+
+    group('isValid()', () {
+      test('returns true for valid album', () {
+        expect(AlbumValidator.isValid('Abbey Road'), isTrue);
+      });
+
+      test('returns false for empty album', () {
+        expect(AlbumValidator.isValid(''), isFalse);
+      });
+    });
+  });
+
+  group('TagValidators convenience access', () {
+    test('provides access to TitleValidator', () {
+      expect(TagValidators.title, isA<TitleValidator>());
+      expect(TagValidators.title.validate('My Song'), isNull);
+      expect(TagValidators.title.validate(''), isNotNull);
+    });
+
+    test('provides access to ArtistValidator', () {
+      expect(TagValidators.artist, isA<ArtistValidator>());
+      expect(TagValidators.artist.validate('The Beatles'), isNull);
+      expect(TagValidators.artist.validate(''), isNotNull);
+    });
+
+    test('provides access to AlbumValidator', () {
+      expect(TagValidators.album, isA<AlbumValidator>());
+      expect(TagValidators.album.validate('Abbey Road'), isNull);
+      expect(TagValidators.album.validate(''), isNotNull);
+    });
+  });
+
+  group('Tag static validator access', () {
+    test('TitleTag provides static validator', () {
+      expect(TitleTag.validator, isA<TitleValidator>());
+      expect(TitleTag.validator.validate('My Song'), isNull);
+    });
+
+    test('ArtistTag provides static validator', () {
+      expect(ArtistTag.validator, isA<ArtistValidator>());
+      expect(ArtistTag.validator.validate('The Beatles'), isNull);
+    });
+
+    test('AlbumTag provides static validator', () {
+      expect(AlbumTag.validator, isA<AlbumValidator>());
+      expect(AlbumTag.validator.validate('Abbey Road'), isNull);
+    });
+  });
+}

--- a/test/validators/validator_system_integration_test.dart
+++ b/test/validators/validator_system_integration_test.dart
@@ -1,0 +1,299 @@
+import 'package:phonic/phonic.dart';
+import 'package:test/test.dart';
+
+/// Integration tests for the public validator system
+void main() {
+  group('Validator System Integration', () {
+    group('End-to-End Workflow', () {
+      test('validates input, creates tag, and uses in audio file workflow', () {
+        // Simulate user input
+        final userInput = 85;
+
+        // Step 1: Validate before creating tag
+        final error = TagValidators.rating.validate(userInput);
+        expect(error, isNull, reason: 'Input should be valid');
+
+        // Step 2: Create tag since validation passed
+        final tag = RatingTag(userInput);
+        expect(tag.value, equals(userInput));
+
+        // Step 3: Tag can be used in audio file operations
+        expect(tag.key, equals(TagKey.rating));
+        expect(tag.provenance, isA<TagProvenance>());
+      });
+
+      test('prevents invalid tag creation through validation', () {
+        final invalidInput = 150;
+
+        // Step 1: Validate first
+        final error = TagValidators.rating.validate(invalidInput);
+        expect(error, isNotNull, reason: 'Invalid input should fail validation');
+
+        // Step 2: Don't create tag if validation failed
+        if (error != null) {
+          final errorMessage = RatingTag.validator.formatErrorMessage(error);
+          expect(errorMessage, contains('Rating must be between 0 and 100'));
+
+          // Verify tag constructor would also fail
+          expect(
+            () => RatingTag(invalidInput),
+            throwsA(isA<ArgumentError>()),
+          );
+        }
+      });
+    });
+
+    group('Validator Consistency', () {
+      test('tag validator and TagValidators provide same results', () {
+        final testValues = [-10, 0, 50, 100, 150];
+
+        for (final value in testValues) {
+          final error1 = RatingTag.validator.validate(value);
+          final error2 = TagValidators.rating.validate(value);
+
+          expect(
+            error1,
+            equals(error2),
+            reason: 'Both access methods should return identical results for $value',
+          );
+        }
+      });
+
+      test('validation and constructor behavior are aligned', () {
+        final testCases = [
+          (-1, false),
+          (0, true),
+          (50, true),
+          (100, true),
+          (101, false),
+        ];
+
+        for (final (value, shouldBeValid) in testCases) {
+          final validationError = TagValidators.rating.validate(value);
+          final isValidByValidator = validationError == null;
+
+          expect(isValidByValidator, equals(shouldBeValid));
+
+          if (shouldBeValid) {
+            expect(() => RatingTag(value), returnsNormally);
+          } else {
+            expect(() => RatingTag(value), throwsA(isA<ArgumentError>()));
+          }
+        }
+      });
+    });
+
+    group('Validator Access Patterns', () {
+      test('all access patterns work correctly', () {
+        final value = 75;
+
+        // Pattern 1: Via TagValidators
+        final result1 = TagValidators.rating.validate(value);
+
+        // Pattern 2: Via tag class
+        final result2 = RatingTag.validator.validate(value);
+
+        // Pattern 3: Direct instantiation
+        const validator = RatingValidator();
+        final result3 = validator.validate(value);
+
+        expect(result1, isNull);
+        expect(result2, isNull);
+        expect(result3, isNull);
+        expect(result1, equals(result2));
+        expect(result2, equals(result3));
+      });
+
+      test('validator constants are accessible from multiple sources', () {
+        // From validator class
+        expect(RatingValidator.min, equals(0));
+        expect(RatingValidator.max, equals(100));
+
+        // From tag class (should reference validator)
+        expect(RatingTag.minRating, equals(RatingValidator.min));
+        expect(RatingTag.maxRating, equals(RatingValidator.max));
+      });
+    });
+
+    group('Error Message Consistency', () {
+      test('formatted messages match expected format', () {
+        final testCases = [
+          (-1, 'Rating must be between 0 and 100 (inclusive)'),
+          (101, 'Rating must be between 0 and 100 (inclusive)'),
+          (1000, 'Rating must be between 0 and 100 (inclusive)'),
+        ];
+
+        for (final (value, expectedMessage) in testCases) {
+          final error = TagValidators.rating.validate(value);
+          expect(error, isNotNull);
+
+          final message = RatingTag.validator.formatErrorMessage(error!);
+          expect(message, equals(expectedMessage));
+        }
+      });
+
+      test('ArgumentError from validateOrThrow uses formatted message', () {
+        try {
+          RatingTag.validator.validateOrThrow(150);
+          fail('Should have thrown ArgumentError');
+        } on ArgumentError catch (e) {
+          expect(
+            e.message,
+            equals('Rating must be between 0 and 100 (inclusive)'),
+          );
+        }
+      });
+    });
+
+    group('Null Handling', () {
+      test('validators handle null appropriately', () {
+        // Validators return null for null input (indicating "no error")
+        final error = TagValidators.rating.validate(null);
+        expect(error, isNull);
+
+        // But tag constructor cannot accept null (compile-time type safety)
+        // This would be a compile error: RatingTag(null);
+      });
+
+      test('isValid handles null correctly', () {
+        expect(RatingValidator.isValid(null), isTrue);
+        expect(RatingValidator.isValid(50), isTrue);
+        expect(RatingValidator.isValid(150), isFalse);
+      });
+    });
+
+    group('Form Integration Simulation', () {
+      test('simulates reactive_forms validation flow', () {
+        // Simulate form control value
+        int? formValue = 50;
+
+        // Validator function for forms
+        Map<String, dynamic>? formValidator(dynamic value) {
+          return TagValidators.rating.validate(value as int?);
+        }
+
+        // Valid value
+        expect(formValidator(formValue), isNull);
+
+        // Invalid value
+        formValue = 150;
+        final error = formValidator(formValue);
+        expect(error, isNotNull);
+        final rangeError = error!['outOfRange'] as Map<String, dynamic>;
+        expect(rangeError['actual'], equals(150));
+
+        // Null value (optional field)
+        formValue = null;
+        expect(formValidator(formValue), isNull);
+      });
+
+      test('custom error message generation for forms', () {
+        String getCustomErrorMessage(Map<String, dynamic> error) {
+          final data = error['outOfRange'] as Map<String, dynamic>;
+          return 'Please enter a value between ${data['min']} and ${data['max']}. You entered ${data['actual']}.';
+        }
+
+        final error = TagValidators.rating.validate(200);
+        expect(error, isNotNull);
+
+        final message = getCustomErrorMessage(error!);
+        expect(
+          message,
+          equals('Please enter a value between 0 and 100. You entered 200.'),
+        );
+      });
+    });
+
+    group('Batch Validation Scenarios', () {
+      test('filters valid values from batch', () {
+        final inputs = [-5, 0, 25, 50, 75, 100, 150, 200];
+
+        final validInputs = inputs.where((value) {
+          return TagValidators.rating.validate(value) == null;
+        }).toList();
+
+        expect(validInputs, equals([0, 25, 50, 75, 100]));
+      });
+
+      test('collects errors for invalid values', () {
+        final inputs = [-5, 150, 200];
+
+        final errors = inputs.map((value) {
+          final error = TagValidators.rating.validate(value);
+          return {
+            'value': value,
+            'error': error,
+          };
+        }).toList();
+
+        expect(errors.length, equals(3));
+        expect(errors.every((e) => e['error'] != null), isTrue);
+      });
+    });
+
+    group('Real-World Use Cases', () {
+      test('pre-validation prevents exception handling', () {
+        final userInputs = [85, 150, -5, 92];
+        final validTags = <RatingTag>[];
+        final errors = <String>[];
+
+        for (final input in userInputs) {
+          final error = TagValidators.rating.validate(input);
+          if (error == null) {
+            validTags.add(RatingTag(input));
+          } else {
+            errors.add(
+              'Value $input: ${RatingTag.validator.formatErrorMessage(error)}',
+            );
+          }
+        }
+
+        expect(validTags.length, equals(2));
+        expect(validTags.map((t) => t.value).toList(), equals([85, 92]));
+        expect(errors.length, equals(2));
+      });
+
+      test('form model with validation', () {
+        // Simulate a form model
+        int? rating;
+
+        String? getRatingError() {
+          if (rating == null) return null;
+          final error = TagValidators.rating.validate(rating);
+          return error != null ? RatingTag.validator.formatErrorMessage(error) : null;
+        }
+
+        // No rating set
+        expect(getRatingError(), isNull);
+
+        // Valid rating
+        rating = 85;
+        expect(getRatingError(), isNull);
+
+        // Invalid rating
+        rating = 150;
+        expect(getRatingError(), isNotNull);
+        expect(getRatingError(), contains('Rating must be between'));
+      });
+    });
+
+    group('Type Safety', () {
+      test('validator is properly typed', () {
+        const validator = RatingValidator();
+        expect(validator, isA<TagValidator<int>>());
+        expect(validator, isA<RatingValidator>());
+      });
+
+      test('error map structure is validated', () {
+        final error = TagValidators.rating.validate(150);
+        expect(error, isNotNull);
+        expect(error!['outOfRange'], isA<Map<String, dynamic>>());
+
+        final rangeError = error['outOfRange'] as Map<String, dynamic>;
+        expect(rangeError['min'], isA<int>());
+        expect(rangeError['max'], isA<int>());
+        expect(rangeError['actual'], isA<int>());
+      });
+    });
+  });
+}


### PR DESCRIPTION
### Added

- Public validator API for form integration and input validation
- `TagValidator<T>` base class with `validate()`, `validateOrThrow()`, and `formatErrorMessage()` methods
- Numeric validators: `RatingValidator`, `BpmValidator`, `YearValidator`, `TrackNumberValidator`, `DiscNumberValidator`
- Date validator: `DateRecordedValidator` with comprehensive ISO-8601 format validation
- Text validators: `TitleValidator`, `ArtistValidator`, `AlbumValidator` for required field validation
- `TagValidators` convenience class providing static access to all validators
- Static validator constants on tag classes (e.g., `TitleTag.validator`, `RatingTag.validator`)
- `reactive_forms` integration support via `Validators.delegate()`
- Comprehensive validator test suite with 153+ tests covering all validators
- Automatic value normalization (trimming whitespace) in text validators